### PR TITLE
Text view fixes and improvements

### DIFF
--- a/Shared/Flows/Onboarding/UserOnboardingViewController.swift
+++ b/Shared/Flows/Onboarding/UserOnboardingViewController.swift
@@ -17,8 +17,8 @@ class UserOnboardingViewController: ViewController {
 
     private(set) var nameLabel = Label(font: .mediumThin, textColor: .textColor)
     private(set) var bubbleView = SpeechBubbleView(orientation: .up,
-                                                   bubbleColor: Color.white.color,
-                                                   borderColor: Color.white.color)
+                                                   bubbleColor: Color.white,
+                                                   borderColor: Color.white)
     private(set) var textView = OnboardingMessageTextView()
 
     override func initializeViews() {
@@ -45,7 +45,7 @@ class UserOnboardingViewController: ViewController {
         if let text = self.getMessage() {
             self.textView.isHidden = false
             self.bubbleView.isHidden = false
-            self.textView.set(text: text)
+            self.textView.setText(text)
             self.view.layoutNow()
         } else {
             self.textView.isHidden = true
@@ -71,9 +71,9 @@ class UserOnboardingViewController: ViewController {
 
         let maxWidth = self.view.width - (Theme.contentOffset.doubled.doubled)
 
-        self.textView.setSize(withWidth: maxWidth)
+        self.textView.setSize(withMaxWidth: maxWidth)
 
-        self.bubbleView.height = self.textView.height + 20 + self.bubbleView.tailLength
+        self.bubbleView.height = self.textView.height + Theme.contentOffset + self.bubbleView.tailLength
         self.bubbleView.width = self.textView.width + 28
         self.bubbleView.match(.top, to: .bottom, of: self.avatarView, offset: Theme.contentOffset.half)
         self.bubbleView.centerOnX()
@@ -104,17 +104,7 @@ class OnboardingMessageTextView: TextView {
         self.textAlignment = .center
         self.textContainer.lineBreakMode = .byWordWrapping
         self.isEditable = false
-    }
-
-    func set(text: Localized) {
-        self.text = localized(text)
-
-        let style = NSMutableParagraphStyle()
-        style.lineSpacing = 2
-        style.alignment = .center
-
         self.linkTextAttributes = [.foregroundColor: Color.lightGray.color, .underlineStyle: 0]
-
-        self.addTextAttributes([NSAttributedString.Key.paragraphStyle: style])
+        self.lineSpacing = 2
     }
 }

--- a/Shared/Flows/Onboarding/UserOnboardingViewController.swift
+++ b/Shared/Flows/Onboarding/UserOnboardingViewController.swift
@@ -113,6 +113,8 @@ class OnboardingMessageTextView: TextView {
         style.lineSpacing = 2
         style.alignment = .center
 
+        self.linkTextAttributes = [.foregroundColor: Color.lightGray.color, .underlineStyle: 0]
+
         self.addTextAttributes([NSAttributedString.Key.paragraphStyle: style])
     }
 }

--- a/Shared/Flows/Onboarding/UserOnboardingViewController.swift
+++ b/Shared/Flows/Onboarding/UserOnboardingViewController.swift
@@ -102,21 +102,12 @@ class OnboardingMessageTextView: TextView {
         self.isScrollEnabled = false
         self.isSelectable = false
         self.textAlignment = .center
+        self.textContainer.lineBreakMode = .byWordWrapping
+        self.isEditable = false
     }
 
     func set(text: Localized) {
-        let textColor: Color = .textColor
-        let attributedString = AttributedString(text,
-                                                fontType: .smallBold,
-                                                color: textColor)
-
-        self.set(attributed: attributedString,
-                 alignment: .center,
-                 lineCount: 0,
-                 lineBreakMode: .byWordWrapping,
-                 stringCasing: .unchanged,
-                 isEditable: false,
-                 linkColor: .white)
+        self.text = localized(text)
 
         let style = NSMutableParagraphStyle()
         style.lineSpacing = 2

--- a/Shared/Models/Message Model/MessageContext.swift
+++ b/Shared/Models/Message Model/MessageContext.swift
@@ -20,9 +20,9 @@ enum MessageContext: String, CaseIterable {
         case .timeSensitive:
             return .red
         case .passive:
-            return .textColor
+            return .white
         case .status:
-            return .textColor
+            return .white
         }
     }
 

--- a/Shared/UI/Views/ConnectionRequestView.swift
+++ b/Shared/UI/Views/ConnectionRequestView.swift
@@ -96,7 +96,7 @@ class ConnectionRequestView: View {
         self.avatarView.setSize(for: self.containerView.height - Theme.contentOffset)
 
         let maxLabelWidth = self.containerView.width - self.avatarView.right - Theme.contentOffset
-        self.textView.setSize(withWidth: maxLabelWidth)
+        self.textView.setSize(withMaxWidth: maxLabelWidth)
         self.textView.match(.top, to: .top, of: self.avatarView)
         self.textView.match(.left, to: .right, of: self.avatarView, offset: Theme.contentOffset.half)
 

--- a/Shared/UI/Views/ConnectionRequestView.swift
+++ b/Shared/UI/Views/ConnectionRequestView.swift
@@ -72,10 +72,9 @@ class ConnectionRequestView: View {
             let userWithData = try await user.retrieveDataIfNeeded()
             if let status = item.status, status == .invited {
                 let text = LocalizedString(id: "", arguments: [userWithData.fullName], default: "[@(name)](\(user.objectId!)) has invited you to connect.")
-                let attributedString = AttributedString(text,
-                                                        fontType: .regular,
-                                                        color: .white)
-                self.textView.set(attributed: attributedString, linkColor: .lightGray)
+
+                self.textView.linkTextAttributes = [.foregroundColor: Color.lightGray.color, .underlineStyle: 0]
+                self.textView.text = localized(text)
                 self.avatarView.set(avatar: userWithData)
                 self.layoutNow()
             } else {

--- a/Shared/UI/Views/Label.swift
+++ b/Shared/UI/Views/Label.swift
@@ -118,16 +118,6 @@ class Label: UILabel {
         attributedString.addAttributes(self.attributes, range: NSRange(location: 0,
                                                                        length: attributedString.length))
 
-        let fontSize: CGFloat = self.font?.pointSize ?? UIFont.systemFontSize
-        // NOTE: Some emojis don't display properly with certain attributes applied to them
-        // So remove attributes from emoji characters.
-        for emojiRange in newText.getEmojiRanges() {
-            attributedString.removeAttributes(atRange: emojiRange)
-            if let emojiFont = UIFont(name: "AppleColorEmoji", size: fontSize) {
-                attributedString.addAttributes([NSAttributedString.Key.font: emojiFont], range: emojiRange)
-            }
-        }
-
         super.attributedText = attributedString
     }
 }

--- a/Shared/UI/Views/Label.swift
+++ b/Shared/UI/Views/Label.swift
@@ -101,7 +101,10 @@ class Label: UILabel {
     }
 
     func add(attributes: [NSAttributedString.Key : Any], to text: String) {
-        guard let existingText = self.attributedText, let range = existingText.string.range(of: text) else { return }
+        guard let existingText = self.attributedText, let range = existingText.string.range(of: text) else {
+            return
+        }
+        
         let attributedString = NSMutableAttributedString(existingText)
         attributedString.addAttributes(attributes, range: range.nsRange(text))
         super.attributedText = attributedString

--- a/Shared/UI/Views/Label.swift
+++ b/Shared/UI/Views/Label.swift
@@ -25,17 +25,6 @@ class Label: UILabel {
         }
     }
 
-    override var attributedText: NSAttributedString? {
-        get { return super.attributedText }
-        set {
-            guard let attributedString = newValue else {
-                super.attributedText = nil
-                return
-            }
-            self.setAttributedTextWithAttributes(attributedString)
-        }
-    }
-
     /// Kerning to be applied to all text in this label. If an attributed string is set manually, there is no guarantee that this variable
     /// will be accurate, but setting it will update kerning on all text in the label.
     var kerning: CGFloat {
@@ -70,7 +59,9 @@ class Label: UILabel {
         
         self.kerning = font.kern
         self.stringCasing = .unchanged
+
         super.init(frame: frame)
+
         self.font = font.font
         self.textColor = textColor.color
         self.initializeLabel()
@@ -79,7 +70,9 @@ class Label: UILabel {
     required init?(coder: NSCoder) {
         self.kerning = 0
         self.stringCasing = .unchanged
+
         super.init(coder: coder)
+
         self.initializeLabel()
     }
 
@@ -115,7 +108,6 @@ class Label: UILabel {
     }
 
     private func setTextWithAttributes(_ newText: String) {
-
         let string = self.stringCasing.format(string: newText)
 
         // Create an attributed string and add attributes to the entire range.
@@ -134,36 +126,6 @@ class Label: UILabel {
         }
 
         super.attributedText = attributedString
-    }
-
-    /// Applies the font, color and kerning to the provided string while preserving any other attributes, then sets it as the attributed text.
-    private func setAttributedTextWithAttributes(_ newText: NSAttributedString) {
-        let attributedString = NSMutableAttributedString(string: newText.string)
-        attributedString.addAttributes(newText.existingAttributes ?? [:])
-        attributedString.addAttributes(self.attributes, range: NSRange(location: 0,
-                                                                       length: attributedString.length))
-        super.attributedText = attributedString
-    }
-
-    func set(attributed: AttributedString,
-             alignment: NSTextAlignment = .left,
-             lineCount: Int = 0,
-             lineBreakMode: NSLineBreakMode = .byWordWrapping,
-             stringCasing: StringCasing = .unchanged) {
-
-        let string = stringCasing.format(string: attributed.string.string)
-        let newString = NSMutableAttributedString(string: string)
-        newString.addAttributes(attributed.attributes,
-                                range: NSRange(location: 0, length: newString.length))
-        // NOTE: Some emojis don't display properly with certain attributes applied to them
-        for emojiRange in string.getEmojiRanges() {
-            newString.removeAttributes(atRange: emojiRange)
-        }
-
-        self.attributedText = newString
-        self.numberOfLines = lineCount
-        self.lineBreakMode = lineBreakMode
-        self.textAlignment = alignment
     }
 }
 

--- a/Shared/UI/Views/SpeechBubbleView.swift
+++ b/Shared/UI/Views/SpeechBubbleView.swift
@@ -82,6 +82,10 @@ class SpeechBubbleView: View {
         self.borderColor = borderColor
     }
 
+    convenience init(orientation: TailOrientation, bubbleColor: Color, borderColor: Color) {
+        self.init(orientation: orientation, bubbleColor: bubbleColor.color, borderColor: borderColor.color)
+    }
+
     required init?(coder aDecoder: NSCoder) {
         self.orientation = .down
 

--- a/Shared/UI/Views/TextView.swift
+++ b/Shared/UI/Views/TextView.swift
@@ -229,20 +229,15 @@ class TextView: UITextView {
             return CGSize.zero
         }
 
-        let attributes = attText.attributes(at: 0,
-                                            longestEffectiveRange: nil,
-                                            in: NSRange(location: 0, length: attText.length))
-
         let horizontalPadding = self.contentInset.horizontal + self.textContainerInset.horizontal
         let verticalPadding = self.contentInset.vertical + self.textContainerInset.vertical
 
         // Get the max size available for the text, taking the textview's insets into account.
         let maxTextSize = CGSize(width: maxWidth - horizontalPadding, height: maxHeight - verticalPadding)
 
-        var size: CGSize = text.boundingRect(with: maxTextSize,
-                                             options: .usesLineFragmentOrigin,
-                                             attributes: attributes,
-                                             context: nil).size
+        var size: CGSize = attText.boundingRect(with: maxTextSize,
+                                                options: .usesLineFragmentOrigin,
+                                                context: nil).size
 
         // Add back the spacing for the text container insets, but ensure we don't exceed the maximum.
         size.width += horizontalPadding

--- a/Shared/UI/Views/TextView.swift
+++ b/Shared/UI/Views/TextView.swift
@@ -25,7 +25,7 @@ class TextView: UITextView {
         set {
             guard let string = newValue, !string.isEmpty else {
                 // No need to apply attributes to a nil string.
-                super.text = " "
+                super.text = ""
                 return
             }
 
@@ -38,7 +38,11 @@ class TextView: UITextView {
     override var font: UIFont? {
         get { return self._font }
         set {
+            super.font = newValue
             self._font = newValue ?? UIFont.systemFont(ofSize: UIFont.systemFontSize)
+
+            guard let text = self.text else { return }
+            self.setTextWithAttributes(text)
         }
     }
     private var _font: UIFont
@@ -48,7 +52,11 @@ class TextView: UITextView {
     override var textColor: UIColor? {
         get { return self._textColor }
         set {
+            super.textColor = newValue
             self._textColor = newValue ?? UIColor.black
+
+            guard let text = self.text else { return }
+            self.setTextWithAttributes(text)
         }
     }
     private var _textColor: UIColor
@@ -73,15 +81,13 @@ class TextView: UITextView {
 
     /// The string attributes to apply to any text given this label's assigned font and font color.
     private var attributes: [NSAttributedString.Key: Any] {
-        let font = self._font
-        let textColor = self._textColor
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = self.textAlignment
         paragraphStyle.lineSpacing = self.lineSpacing
 
-        return [.font: font,
+        return [.font: self._font,
                 .kern: self.kerning,
-                .foregroundColor: textColor,
+                .foregroundColor: self._textColor,
                 .paragraphStyle: paragraphStyle]
     }
 
@@ -91,7 +97,11 @@ class TextView: UITextView {
         }
     }
 
-    init(frame: CGRect = .zero, font: FontType, textColor: Color, textContainer: NSTextContainer?) {
+    init(frame: CGRect = .zero,
+         font: FontType,
+         textColor: Color,
+         textContainer: NSTextContainer?) {
+
         self._font = font.font
         self._textColor = textColor.color
         self.kerning = font.kern
@@ -109,6 +119,8 @@ class TextView: UITextView {
         super.init(coder: aDecoder)
 
         self.initializeViews()
+
+        self.text = nil
     }
 
     convenience init() {
@@ -116,9 +128,6 @@ class TextView: UITextView {
     }
 
     func initializeViews() {
-        let styleAttributes = StringStyle(font: .smallBold, color: .white).attributes
-        self.typingAttributes = styleAttributes
-
         self.contentMode = .redraw
 
         self.keyboardAppearance = .dark
@@ -146,7 +155,7 @@ class TextView: UITextView {
     
     func setText(_ localizedText: Localized?) {
         guard let localizedText = localizedText else {
-            self.text = " "
+            self.text = ""
             return
         }
         self.text = localized(localizedText)
@@ -195,7 +204,7 @@ class TextView: UITextView {
     }
 
     func reset() {
-        self.text = " "
+        self.text = ""
         self.textDidChange()
     }
 

--- a/Shared/UI/Views/TextView.swift
+++ b/Shared/UI/Views/TextView.swift
@@ -21,9 +21,7 @@ class TextView: UITextView {
     var cancellables = Set<AnyCancellable>()
 
     override var text: String! {
-        get {
-            return super.text
-        }
+        get { return super.text }
         set {
             guard let string = newValue, !string.isEmpty else {
                 // No need to apply attributes to a nil string.
@@ -34,6 +32,26 @@ class TextView: UITextView {
             self.setTextWithAttributes(string)
         }
     }
+
+    // Back the normal font variable with a private variable to ensure that the
+    // font type doesn't get set wrong when dealing with emojis.
+    override var font: UIFont? {
+        get { return self._font }
+        set {
+            self._font = newValue ?? UIFont.systemFont(ofSize: UIFont.systemFontSize)
+        }
+    }
+    private var _font: UIFont
+
+    // Back the normal text color variable with a private variable to ensure that the
+    // color doesn't get set wrong when dealing with emojis.
+    override var textColor: UIColor? {
+        get { return self._textColor }
+        set {
+            self._textColor = newValue ?? UIColor.black
+        }
+    }
+    private var _textColor: UIColor
 
     /// Kerning to be applied to all text in this text view. If an attributed string is set manually, there is no guarantee that this variable
     /// will be accurate, but setting it will update kerning on all text in the label.
@@ -55,8 +73,8 @@ class TextView: UITextView {
 
     /// The string attributes to apply to any text given this label's assigned font and font color.
     private var attributes: [NSAttributedString.Key: Any] {
-        let font = self.font ?? UIFont.systemFont(ofSize: UIFont.systemFontSize)
-        let textColor = self.textColor ?? UIColor.black
+        let font = self._font
+        let textColor = self._textColor
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = self.textAlignment
         paragraphStyle.lineSpacing = self.lineSpacing
@@ -74,29 +92,21 @@ class TextView: UITextView {
     }
 
     init(frame: CGRect = .zero, font: FontType, textColor: Color, textContainer: NSTextContainer?) {
+        self._font = font.font
+        self._textColor = textColor.color
         self.kerning = font.kern
 
         super.init(frame: frame, textContainer: textContainer)
-
-        // Ensure that there's always some text in this text view so font color and text color properties
-        // don't become nil
-        self.text = " "
-        self.font = font.font
-        self.textColor = textColor.color
 
         self.initializeViews()
     }
 
     required init?(coder aDecoder: NSCoder) {
+        self._font = FontType.smallBold.font
+        self._textColor = UIColor.black
         self.kerning = FontType.smallBold.kern
 
         super.init(coder: aDecoder)
-
-        // Ensure that there's always some text in this text view so font color and text color properties
-        // don't become nil
-        self.text = " "
-        self.font = FontType.smallBold.font
-        self.textColor = Color.textColor.color
 
         self.initializeViews()
     }

--- a/Shared/UI/Views/TextView.swift
+++ b/Shared/UI/Views/TextView.swift
@@ -23,12 +23,8 @@ class TextView: UITextView {
     override var text: String! {
         get { return super.text }
         set {
-            guard let string = newValue, !string.isEmpty else {
-                // No need to apply attributes to an empty string.
-                super.text = newValue
-                return
-            }
-
+            // Always have some text in this textview so that we don't lose the text attributes.
+            let string = newValue ?? ""
             self.setTextWithAttributes(string)
         }
     }
@@ -96,7 +92,6 @@ class TextView: UITextView {
 
         self.initializeViews()
 
-        self.text = nil
     }
 
     convenience init() {
@@ -104,6 +99,9 @@ class TextView: UITextView {
     }
 
     func initializeViews() {
+        // Give the text view an initial value so to get our attributes bootstrapped.
+        self.text = ""
+
         self.contentMode = .redraw
 
         self.keyboardAppearance = .dark
@@ -158,6 +156,8 @@ class TextView: UITextView {
         attributedString.addAttributes(self.attributes,
                                        range: NSRange(location: 0, length: attributedString.length))
         self.attributedText = attributedString
+
+        self.typingAttributes = self.attributes
     }
 
     /// Adds the provided attributes to all the text in the view while preserving the existing attributes.

--- a/Shared/UI/Views/TextView.swift
+++ b/Shared/UI/Views/TextView.swift
@@ -21,9 +21,50 @@ class TextView: UITextView {
     var cancellables = Set<AnyCancellable>()
 
     override var text: String! {
-        didSet {
-            self.setNeedsDisplay()
+        get {
+            return super.text
         }
+        set {
+            guard let string = newValue, !string.isEmpty else {
+                // No need to apply attributes to a nil string.
+                super.text = " "
+                return
+            }
+
+            self.setTextWithAttributes(string)
+        }
+    }
+
+    /// Kerning to be applied to all text in this text view. If an attributed string is set manually, there is no guarantee that this variable
+    /// will be accurate, but setting it will update kerning on all text in the label.
+    var kerning: CGFloat {
+        didSet {
+            guard let text = self.text else { return }
+            self.setTextWithAttributes(text)
+        }
+    }
+
+    /// Line spacing for consecutive lines of text. If an attributed string is set manually, there is no guarantee that this variable
+    /// will be accurate, but setting it will update line spacing on all text in the label.
+    var lineSpacing: CGFloat = 0 {
+        didSet {
+            guard let text = self.text else { return }
+            self.setTextWithAttributes(text)
+        }
+    }
+
+    /// The string attributes to apply to any text given this label's assigned font and font color.
+    private var attributes: [NSAttributedString.Key: Any] {
+        let font = self.font ?? UIFont.systemFont(ofSize: UIFont.systemFontSize)
+        let textColor = self.textColor ?? UIColor.black
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = self.textAlignment
+        paragraphStyle.lineSpacing = self.lineSpacing
+
+        return [.font: font,
+                .kern: self.kerning,
+                .foregroundColor: textColor,
+                .paragraphStyle: paragraphStyle]
     }
 
     private var attributedPlaceholder: NSAttributedString? {
@@ -32,27 +73,52 @@ class TextView: UITextView {
         }
     }
 
-    override init(frame: CGRect, textContainer: NSTextContainer?) {
+    init(frame: CGRect = .zero, font: FontType, textColor: Color, textContainer: NSTextContainer?) {
+        self.kerning = font.kern
+
         super.init(frame: frame, textContainer: textContainer)
+
+        // Ensure that there's always some text in this text view so font color and text color properties
+        // don't become nil
+        self.text = " "
+        self.font = font.font
+        self.textColor = textColor.color
+
+        self.initializeViews()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        self.kerning = FontType.smallBold.kern
+
+        super.init(coder: aDecoder)
+
+        // Ensure that there's always some text in this text view so font color and text color properties
+        // don't become nil
+        self.text = " "
+        self.font = FontType.smallBold.font
+        self.textColor = Color.textColor.color
+
         self.initializeViews()
     }
 
     convenience init() {
-        self.init(frame: .zero, textContainer: nil)
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        super.init(frame: .zero, textContainer: nil)
-        self.initializeViews()
+        self.init(frame: .zero, font: .smallBold, textColor: .textColor, textContainer: nil)
     }
 
     func initializeViews() {
         let styleAttributes = StringStyle(font: .smallBold, color: .white).attributes
         self.typingAttributes = styleAttributes
+
         self.contentMode = .redraw
 
         self.keyboardAppearance = .dark
-        
+
+        self.textContainer.lineBreakMode = .byWordWrapping
+        self.textAlignment = .center
+        self.isUserInteractionEnabled = true
+        self.dataDetectorTypes = .all
+        self.textContainer.lineFragmentPadding = 0
+
         self.set(backgroundColor: .clear)
 
         NotificationCenter.default.publisher(for: UITextView.textDidChangeNotification)
@@ -66,41 +132,60 @@ class TextView: UITextView {
             }.store(in: &self.cancellables)
     }
 
+    // MARK: Setters
+    
+    func setText(_ localizedText: Localized?) {
+        guard let localizedText = localizedText else {
+            self.text = " "
+            return
+        }
+        self.text = localized(localizedText)
+    }
+
+    func setFont(_ fontType: FontType) {
+        self.font = fontType.font
+        self.kerning = fontType.kern
+    }
+
+    func setTextColor(_ textColor: Color) {
+        self.textColor = textColor.color
+    }
+
     func set(placeholder: Localized, color: Color = .textColor) {
         let styleAttributes = StringStyle(font: .smallBold, color: color).attributes
         let string = NSAttributedString(string: localized(placeholder), attributes: styleAttributes)
         self.attributedPlaceholder = string
     }
 
-    func set(attributed: AttributedString,
-             alignment: NSTextAlignment = .left,
-             lineCount: Int = 0,
-             lineBreakMode: NSLineBreakMode = .byWordWrapping,
-             stringCasing: StringCasing = .unchanged,
-             isEditable: Bool = false,
-             linkColor: Color = .white) {
+    private func setTextWithAttributes(_ newText: String) {
+        let attributedString = NSMutableAttributedString(string: newText)
+        attributedString.addAttributes(self.attributes,
+                                       range: NSRange(location: 0, length: attributedString.length))
 
-        let string = stringCasing.format(string: attributed.string.string)
-        let attributedString = NSMutableAttributedString(string: string)
-        attributedString.addAttributes(attributed.attributes, range: NSRange(location: 0,
-                                                                             length: attributedString.length))
+        let fontSize: CGFloat = self.font?.pointSize ?? UIFont.systemFontSize
+        // NOTE: Some emojis don't display properly with certain attributes applied to them
+        for emojiRange in newText.getEmojiRanges() {
+            attributedString.removeAttributes(atRange: emojiRange)
+            if let emojiFont = UIFont(name: "AppleColorEmoji", size: fontSize) {
+                attributedString.addAttributes([NSAttributedString.Key.font: emojiFont], range: emojiRange)
+            }
+        }
 
-        attributedString.linkItems()
-        self.linkTextAttributes = [.foregroundColor: linkColor.color, .underlineStyle: 0]
-
-        self.isEditable = isEditable
         self.attributedText = attributedString
-        self.textContainer.maximumNumberOfLines = lineCount
-        self.textContainer.lineBreakMode = lineBreakMode
-        self.textAlignment = alignment
-        self.isUserInteractionEnabled = true
-        self.dataDetectorTypes = .all
-        self.textContainerInset = .zero
-        self.textContainer.lineFragmentPadding = 0
+    }
+
+    /// Adds the provided attributes to all the text in the view while preserving the existing attributes.
+    func addTextAttributes(_ attributes: [NSAttributedString.Key : Any]) {
+        guard let current = self.attributedText else { return }
+
+        let newString = NSMutableAttributedString(current)
+        let range = NSMakeRange(0, newString.string.count)
+        newString.addAttributes(attributes, range: range)
+        self.attributedText = newString
     }
 
     func reset() {
-        self.text = String()
+        self.text = " "
         self.textDidChange()
     }
 
@@ -154,7 +239,9 @@ class TextView: UITextView {
     }
 
     func getSize(withWidth width: CGFloat, height: CGFloat = CGFloat.infinity) -> CGSize {
-        guard let t = self.text, !t.isEmpty, let attText = self.attributedText else { return CGSize.zero }
+        guard let text = self.text, !text.isEmpty, let attText = self.attributedText else {
+            return CGSize.zero
+        }
 
         let attributes = attText.attributes(at: 0,
                                             longestEffectiveRange: nil,
@@ -163,21 +250,11 @@ class TextView: UITextView {
         let maxSize = CGSize(width: width - self.textContainerInset.left - self.textContainerInset.right,
                              height: height - self.textContainerInset.top - self.textContainerInset.bottom)
 
-        let size: CGSize = t.boundingRect(with: maxSize,
-                                          options: .usesLineFragmentOrigin,
-                                          attributes: attributes,
-                                          context: nil).size
+        let size: CGSize = text.boundingRect(with: maxSize,
+                                             options: .usesLineFragmentOrigin,
+                                             attributes: attributes,
+                                             context: nil).size
 
         return size
-    }
-
-    /// Adds the provided attributes to all the text in the view.
-    func addTextAttributes(_ attributes: [NSAttributedString.Key : Any]) {
-        guard let current = self.attributedText else { return }
-
-        let newString = NSMutableAttributedString(current)
-        let range = NSMakeRange(0, newString.string.count)
-        newString.addAttributes(attributes, range: range)
-        self.attributedText = newString
     }
 }

--- a/iOS/Flows/Conversation/Cells/ConversationMessageCell.swift
+++ b/iOS/Flows/Conversation/Cells/ConversationMessageCell.swift
@@ -157,7 +157,7 @@ class ConversationMessageCell: UICollectionViewCell, ConversationMessageCellLayo
 extension ConversationMessageCell: UICollectionViewDelegateFlowLayout {
 
     /// The space between the top of a cell and tops of adjacent cells in a stack.
-    static var spaceBetweenCellTops: CGFloat { return 15 }
+    static var spaceBetweenCellTops: CGFloat { return 8 }
 
     // MARK: - UICollectionViewDelegateFlowLayout
 
@@ -228,7 +228,7 @@ extension ConversationMessageCell: UICollectionViewDelegateFlowLayout {
             insets.bottom += CGFloat(extraSpacersNeeded) * ConversationMessageCell.spaceBetweenCellTops
         } else if section == 1 {
             // Put some space between the two sections of messages.
-            insets.top = Theme.contentOffset
+            insets.top = Theme.contentOffset.half
 
             // Ensure that the top of the latest user reply in this cell aligns
             // with the tops of the latest user replies in adjacent cells.

--- a/iOS/Flows/Conversation/Cells/ConversationMessageCellLayout.swift
+++ b/iOS/Flows/Conversation/Cells/ConversationMessageCellLayout.swift
@@ -89,13 +89,13 @@ class ConversationMessageCellLayout: UICollectionViewFlowLayout {
         if indexPath.section == 0 {
             // Position the decoration above the frontmost item in the first section
             attributes.frame = CGRect(x: frontmostAttributes.frame.left,
-                                      y: frontmostAttributes.frame.top - Theme.contentOffset,
+                                      y: frontmostAttributes.frame.top - Theme.contentOffset + 7,
                                       width: frontmostAttributes.frame.width,
                                       height: Theme.contentOffset)
         } else {
             // Position the decoration below the frontmost item in the second section
             attributes.frame = CGRect(x: frontmostAttributes.frame.left,
-                                      y: frontmostAttributes.frame.bottom,
+                                      y: frontmostAttributes.frame.bottom - 7,
                                       width: frontmostAttributes.frame.width,
                                       height: Theme.contentOffset)
         }

--- a/iOS/Flows/Conversation/Cells/MessageSubcell.swift
+++ b/iOS/Flows/Conversation/Cells/MessageSubcell.swift
@@ -33,8 +33,7 @@ class MessageSubcell: UICollectionViewCell {
         self.backgroundColorView.roundCorners()
 
         self.backgroundColorView.addSubview(self.textView)
-        self.textView.textAlignment = .center
-        self.textView.textColor = Color.textColor.color
+
         self.textView.textContainer.lineBreakMode = .byTruncatingTail
     }
 
@@ -54,7 +53,7 @@ class MessageSubcell: UICollectionViewCell {
         if message.isDeleted {
             self.textView.text = "DELETED"
         } else {
-            self.textView.text = message.kind.text
+            self.textView.set(text: message.kind.text, messageContext: message.context)
         }
 
         self.setNeedsLayout()
@@ -80,7 +79,7 @@ class MessageSubcell: UICollectionViewCell {
             return
         }
 
-        self.textView.isVisible = messageLayoutAttributes.shouldShowText
+        self.textView.alpha = messageLayoutAttributes.shouldShowText ? 1 : 0.5
         self.configureBackground(color: messageLayoutAttributes.backgroundColor,
                                  showBubbleTail: messageLayoutAttributes.shouldShowTail,
                                  tailOrientation: messageLayoutAttributes.bubbleTailOrientation)

--- a/iOS/Flows/Conversation/Cells/MessageSubcell.swift
+++ b/iOS/Flows/Conversation/Cells/MessageSubcell.swift
@@ -79,7 +79,7 @@ class MessageSubcell: UICollectionViewCell {
             return
         }
 
-        self.textView.alpha = messageLayoutAttributes.shouldShowText ? 1 : 0.5
+        self.textView.isVisible = messageLayoutAttributes.shouldShowText
         self.configureBackground(color: messageLayoutAttributes.backgroundColor,
                                  showBubbleTail: messageLayoutAttributes.shouldShowTail,
                                  tailOrientation: messageLayoutAttributes.bubbleTailOrientation)
@@ -95,6 +95,8 @@ class MessageSubcell: UICollectionViewCell {
         self.backgroundColorView.orientation = tailOrientation
     }
 }
+
+// MARK: - Sizing
 
 extension MessageSubcell {
 
@@ -112,7 +114,7 @@ extension MessageSubcell {
 
         let textView = MessageTextView()
         textView.text = message.kind.text
-        var textViewSize = textView.getSize(withWidth: width)
+        var textViewSize = textView.getSize(withMaxWidth: width)
         textViewSize.height += Theme.contentOffset
         return clamp(textViewSize.height + self.bubbleTailLength,
                      MessageSubcell.minimumHeight,

--- a/iOS/Flows/Conversation/ConversationViewController.swift
+++ b/iOS/Flows/Conversation/ConversationViewController.swift
@@ -99,7 +99,7 @@ class ConversationViewController: FullScreenViewController,
         self.collectionView.match(.top,
                                   to: .bottom,
                                   of: self.conversationHeader,
-                                  offset: -14)
+                                  offset: -16)
         self.collectionView.height = self.contentContainer.height - 96
     }
 

--- a/iOS/Flows/Conversation/Input/ExpandingTextView.swift
+++ b/iOS/Flows/Conversation/Input/ExpandingTextView.swift
@@ -22,8 +22,8 @@ class ExpandingTextView: TextView {
         self.tintColor = Color.darkGray.color
         self.textColor = Color.darkGray.color
 
-        self.textContainerInset.left = 10
-        self.textContainerInset.right = 10
+        self.textContainerInset.left = Theme.contentOffset
+        self.textContainerInset.right = Theme.contentOffset
         self.textContainerInset.top = 14
         self.textContainerInset.bottom = 12
     }

--- a/iOS/Flows/Conversation/Input/ExpandingTextView.swift
+++ b/iOS/Flows/Conversation/Input/ExpandingTextView.swift
@@ -21,8 +21,6 @@ class ExpandingTextView: TextView {
         self.keyboardType = .twitter
         self.tintColor = Color.darkGray.color
         self.textColor = Color.darkGray.color
-        self.textAlignment = .center
-        self.set(backgroundColor: .clear)
 
         self.textContainerInset.left = 10
         self.textContainerInset.right = 10

--- a/iOS/Flows/Conversation/Input/InputTextView.swift
+++ b/iOS/Flows/Conversation/Input/InputTextView.swift
@@ -26,15 +26,16 @@ class InputTextView: ExpandingTextView {
 
     init() {
         super.init(frame: .zero,
-                   font: .small,
+                   font: .smallBold,
                    textColor: .textColor,
                    textContainer: nil)
-
-        self.textAlignment = .center
     }
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+
+        self.font = FontType.smallBold.font
+        self.textColor = Color.textColor.color
     }
 
     override func initializeViews() {

--- a/iOS/Flows/Conversation/Input/InputTextView.swift
+++ b/iOS/Flows/Conversation/Input/InputTextView.swift
@@ -25,7 +25,12 @@ class InputTextView: ExpandingTextView {
     weak var attachmentDelegate: AttachmentViewControllerDelegate?
 
     init() {
-        super.init(frame: .zero, textContainer: nil)
+        super.init(frame: .zero,
+                   font: .small,
+                   textColor: .textColor,
+                   textContainer: nil)
+
+        self.textAlignment = .center
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/iOS/Flows/Conversation/Input/PreviewMessageView.swift
+++ b/iOS/Flows/Conversation/Input/PreviewMessageView.swift
@@ -60,8 +60,8 @@ class PreviewMessageView: SpeechBubbleView {
         self.imageView.height = self.imageView.displayable.isNil ? 0 : 100
         self.imageView.centerOnX()
         
-        self.textView.expandToSuperviewWidth()
-        self.textView.height = self.bubbleFrame.height - self.imageView.height
+        self.textView.setSize(withMaxWidth: self.width)
+        self.textView.centerOnX()
         self.textView.match(.top, to: .bottom, of: self.imageView)
     }
 }

--- a/iOS/Flows/Conversation/MessageDateLabel.swift
+++ b/iOS/Flows/Conversation/MessageDateLabel.swift
@@ -13,7 +13,10 @@ class MessageDateLabel: Label {
     init() {
         super.init(font: .small)
 
-        self.setText(" ")
+        self.textAlignment = .center
+        self.numberOfLines = 1
+        self.setFont(.small)
+        self.setTextColor(.gray)
     }
 
     required init?(coder: NSCoder) {
@@ -22,17 +25,11 @@ class MessageDateLabel: Label {
 
     func set(date: Date?) {
         guard let date = date else {
-            self.setText(" ")
+            self.text = nil
             return
         }
 
-        let attributed = AttributedString(self.getString(for: date),
-                                          fontType: .small,
-                                          color: .lightGray)
-        self.set(attributed: attributed,
-                 alignment: .center,
-                 lineCount: 1,
-                 stringCasing: .unchanged)
+        self.text = self.getString(for: date)
     }
 
     private func getString(for date: Date) -> String {

--- a/iOS/Flows/Conversation/MessageTimeLabel.swift
+++ b/iOS/Flows/Conversation/MessageTimeLabel.swift
@@ -13,7 +13,10 @@ class MessageTimeLabel: Label {
     init() {
         super.init(font: .small)
 
-        self.setText(" ")
+        self.textAlignment = .center
+        self.numberOfLines = 1
+        self.setFont(.small)
+        self.setTextColor(.gray)
     }
 
     required init?(coder: NSCoder) {
@@ -22,16 +25,10 @@ class MessageTimeLabel: Label {
 
     func set(date: Date?) {
         guard let date = date else {
-            self.setText(" ")
+            self.text = nil
             return
         }
 
-        let attributed = AttributedString(Date.hourMinuteTimeOfDay.string(from: date),
-                                          fontType: .small,
-                                          color: .lightGray)
-        self.set(attributed: attributed,
-                 alignment: .center,
-                 lineCount: 1,
-                 stringCasing: .unchanged)
+        self.text = Date.hourMinuteTimeOfDay.string(from: date)
     }
 }

--- a/iOS/Flows/Conversation/Threads/Conversation Collection Views/Cells/Message/MessageTextView.swift
+++ b/iOS/Flows/Conversation/Threads/Conversation Collection Views/Cells/Message/MessageTextView.swift
@@ -25,7 +25,7 @@ class MessageTextView: TextView {
     }
 
     func setText(with message: Messageable) {
-        self.setText(text)
+        self.setText(message.kind.text)
         let textColor: Color = message.context == .status ? .darkGray : .textColor
         self.setTextColor(textColor)
     }

--- a/iOS/Flows/Conversation/Threads/Conversation Collection Views/Cells/Message/MessageTextView.swift
+++ b/iOS/Flows/Conversation/Threads/Conversation Collection Views/Cells/Message/MessageTextView.swift
@@ -13,9 +13,6 @@ class MessageTextView: TextView {
 
     override func initializeViews() {
         super.initializeViews()
-
-        self.lineSpacing = 0
-        self.setFont(.smallBold)
         
         self.isEditable = false
         self.isScrollEnabled = false
@@ -25,8 +22,6 @@ class MessageTextView: TextView {
         self.textContainerInset.bottom = 0
         self.textContainerInset.left = Theme.contentOffset
         self.textContainerInset.right = Theme.contentOffset
-
-        self.backgroundColor = .cyan
     }
 
     func set(text: Localized, messageContext: MessageContext) {

--- a/iOS/Flows/Conversation/Threads/Conversation Collection Views/Cells/Message/MessageTextView.swift
+++ b/iOS/Flows/Conversation/Threads/Conversation Collection Views/Cells/Message/MessageTextView.swift
@@ -14,6 +14,9 @@ class MessageTextView: TextView {
     override func initializeViews() {
         super.initializeViews()
 
+        self.lineSpacing = 0
+        self.setFont(.smallBold)
+        
         self.isEditable = false
         self.isScrollEnabled = false
         self.isSelectable = true
@@ -22,26 +25,15 @@ class MessageTextView: TextView {
         self.textContainerInset.bottom = 0
         self.textContainerInset.left = Theme.contentOffset
         self.textContainerInset.right = Theme.contentOffset
+
+        self.backgroundColor = .cyan
     }
 
     func set(text: Localized, messageContext: MessageContext) {
+        self.setText(text)
+
         let textColor: Color = messageContext == .status ? .darkGray : .textColor
-        let attributedString = AttributedString(text,
-                                                fontType: .smallBold,
-                                                color: textColor)
-
-        self.set(attributed: attributedString,
-                 alignment: .center,
-                 lineCount: 0,
-                 lineBreakMode: .byWordWrapping,
-                 stringCasing: .unchanged,
-                 isEditable: false,
-                 linkColor: .white)
-
-        let style = NSMutableParagraphStyle()
-        style.lineSpacing = 2
-
-        self.addTextAttributes([NSAttributedString.Key.paragraphStyle: style])
+        self.setTextColor(textColor)
     }
 
     // Allows us to interact with links if they exist or pass the touch to the next receiver if they do not

--- a/iOS/Flows/Conversation/Threads/Conversation Collection Views/Cells/Message/MessageTextView.swift
+++ b/iOS/Flows/Conversation/Threads/Conversation Collection Views/Cells/Message/MessageTextView.swift
@@ -18,10 +18,10 @@ class MessageTextView: TextView {
         self.isScrollEnabled = false
         self.isSelectable = true
 
-        self.textContainerInset.top = 0
-        self.textContainerInset.bottom = 0
         self.textContainerInset.left = Theme.contentOffset
         self.textContainerInset.right = Theme.contentOffset
+        self.textContainerInset.top = 0
+        self.textContainerInset.bottom = 0
     }
 
     func set(text: Localized, messageContext: MessageContext) {

--- a/iOS/Flows/Conversation/Threads/Conversation Collection Views/Cells/Message/MessageTextView.swift
+++ b/iOS/Flows/Conversation/Threads/Conversation Collection Views/Cells/Message/MessageTextView.swift
@@ -26,7 +26,7 @@ class MessageTextView: TextView {
 
     func setText(with message: Messageable) {
         self.setText(text)
-        let textColor: Color = message.messageContext == .status ? .darkGray : .textColor
+        let textColor: Color = message.context == .status ? .darkGray : .textColor
         self.setTextColor(textColor)
     }
 

--- a/iOS/Flows/Conversation/Threads/Conversation Collection Views/Cells/Message/ReplyMessageCell.swift
+++ b/iOS/Flows/Conversation/Threads/Conversation Collection Views/Cells/Message/ReplyMessageCell.swift
@@ -74,7 +74,7 @@ class ReplyMessageCell: BaseMessageCell {
 
         self.bubbleView.expandToSuperviewSize()
         self.bubbleView.roundCorners()
-        self.textView.setSize(withWidth: self.contentView.width)
+        self.textView.setSize(withMaxWidth: self.contentView.width)
         self.textView.centerOnXAndY()
     }
 

--- a/iOS/Flows/Home/Notices/AlertCell.swift
+++ b/iOS/Flows/Home/Notices/AlertCell.swift
@@ -58,7 +58,7 @@ class AlertCell: NoticeCell {
         self.avatarView.pin(.top, padding: Theme.contentOffset.half)
 
         let maxWidth = self.contentView.width - self.avatarView.right - Theme.contentOffset.doubled
-        self.textView.setSize(withWidth: maxWidth, height: self.contentView.height - Theme.contentOffset.doubled)
+        self.textView.setSize(withMaxWidth: maxWidth, maxHeight: self.contentView.height - Theme.contentOffset.doubled)
 
         self.bubbleView.height = self.textView.height + Theme.contentOffset
         self.bubbleView.width = self.textView.width + Theme.contentOffset

--- a/iOS/UI/Swipeable Input/ConversationInputAccessoryView.xib
+++ b/iOS/UI/Swipeable Input/ConversationInputAccessoryView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,24 +18,24 @@
                     <rect key="frame" x="0.0" y="0.0" width="337" height="114"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6QT-73-Nac" customClass="InputActivityBar" customModule="Jibber" customModuleProvider="target">
-                            <rect key="frame" x="24" y="0.0" width="289" height="28"/>
+                            <rect key="frame" x="33.5" y="0.0" width="270" height="28"/>
                             <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="28" id="Qcc-5W-wS4"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VuQ-5S-h7F" customClass="SpeechBubbleView" customModule="Jibber" customModuleProvider="target">
-                            <rect key="frame" x="24" y="28" width="289" height="76"/>
+                            <rect key="frame" x="33.5" y="28" width="270" height="76"/>
                             <subviews>
                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" text="This is some example message text" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Ads-9e-WJh" customClass="InputTextView" customModule="Jibber" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="289" height="66"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="270" height="66"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <color key="textColor" systemColor="labelColor"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 </textView>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b2H-ok-H5y">
-                                    <rect key="frame" x="0.0" y="0.0" width="289" height="76"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="270" height="76"/>
                                     <state key="normal" title="Button"/>
                                     <buttonConfiguration key="configuration" style="plain" title=""/>
                                 </button>
@@ -56,11 +56,11 @@
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstItem="6QT-73-Nac" firstAttribute="top" secondItem="CP8-gi-eym" secondAttribute="top" id="0H2-Xo-SXZ"/>
-                        <constraint firstAttribute="trailing" secondItem="VuQ-5S-h7F" secondAttribute="trailing" constant="24" id="Tgi-A5-L3c"/>
+                        <constraint firstItem="VuQ-5S-h7F" firstAttribute="centerX" secondItem="CP8-gi-eym" secondAttribute="centerX" id="4Ql-5P-HK6"/>
                         <constraint firstItem="VuQ-5S-h7F" firstAttribute="top" secondItem="6QT-73-Nac" secondAttribute="bottom" id="ZSd-AH-VpD"/>
-                        <constraint firstItem="VuQ-5S-h7F" firstAttribute="leading" secondItem="CP8-gi-eym" secondAttribute="leading" constant="24" id="Zve-FB-6La"/>
                         <constraint firstItem="VuQ-5S-h7F" firstAttribute="trailing" secondItem="6QT-73-Nac" secondAttribute="trailing" id="lDj-vr-jFz"/>
                         <constraint firstItem="VuQ-5S-h7F" firstAttribute="leading" secondItem="6QT-73-Nac" secondAttribute="leading" id="qmj-x7-7Tm"/>
+                        <constraint firstItem="VuQ-5S-h7F" firstAttribute="width" secondItem="CP8-gi-eym" secondAttribute="width" multiplier="0.8" id="yt1-hm-YhG"/>
                         <constraint firstAttribute="bottom" secondItem="VuQ-5S-h7F" secondAttribute="bottom" constant="10" id="z6m-Oo-aFo"/>
                     </constraints>
                 </view>


### PR DESCRIPTION
This is prep work for moving up the UI as user types longer messages.

I fixed text view sizing functions so they take content insets into account.

I made the text view easier to set up and use. Primarily removing the need to have "setText" functions that take so many arguments. Instead you just set text view properties as desired and all future text will have those properties.

Also, the input text field more closely matches the message cell sizing. In the video, note how the bubble widths are now the same and the number of text lines stays the same as well.

https://user-images.githubusercontent.com/88675954/141347694-927f90a4-3e16-495c-b749-143bb97b0eb5.mp4


