### PR TITLE
Martin/ios 278 time machine layout is wrong for

### DIFF
--- a/iOS/Flows/Conversation/Cells/TimeMachineCollectionViewLayout.swift
+++ b/iOS/Flows/Conversation/Cells/TimeMachineCollectionViewLayout.swift
@@ -26,9 +26,6 @@ class TimeMachineCollectionViewLayout: UICollectionViewLayout {
 
     private typealias SectionIndex = Int
 
-    override class var layoutAttributesClass: AnyClass {
-        return ConversationMessageCellLayoutAttributes.self
-    }
     override class var invalidationContextClass: AnyClass {
         return TimeMachineCollectionViewLayoutInvalidationContext.self
     }


### PR DESCRIPTION
Fixes and performance improvements to the time machine layout.

Scrolling is super smooth now.

https://user-images.githubusercontent.com/88675954/143147938-d4968400-85ae-420c-8669-cf2a909f03cd.MP4

