### PR TITLE
Making the animation fixes in the time machine layout less hacky.

### DIFF
--- a/iOS/Flows/Conversation/Cells/ConversationMessagesCell.swift
+++ b/iOS/Flows/Conversation/Cells/ConversationMessagesCell.swift
@@ -164,11 +164,6 @@ class ConversationMessagesCell: UICollectionViewCell, ConversationMessageCellLay
         self.dataSource.apply(snapshot, animatingDifferences: false)
     }
 
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
-        self.dataSource.apply(snapshot, animatingDifferences: animateDifference)
-    }
-
     func handle(isCentered: Bool) {
         guard self.collectionLayout.showMessageStatus != isCentered else { return }
 

--- a/iOS/Flows/Conversation/Cells/TimeMachineCollectionViewLayout.swift
+++ b/iOS/Flows/Conversation/Cells/TimeMachineCollectionViewLayout.swift
@@ -220,7 +220,7 @@ class TimeMachineCollectionViewLayout: UICollectionViewLayout {
 
     override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
         // Return all items whose frames intersect with the given rect.
-        var itemAttributes = self.cellLayoutAttributes.values.filter { attributes in
+        let itemAttributes = self.cellLayoutAttributes.values.filter { attributes in
             return rect.intersects(attributes.frame)
         }
 
@@ -436,6 +436,8 @@ class TimeMachineCollectionViewLayout: UICollectionViewLayout {
 
     /// If true, scroll to the most recent item after performing collection view updates.
     private var shouldScrollToEnd = false
+    private var deletedIndexPaths: Set<IndexPath> = []
+    private var insertedIndexPaths: Set<IndexPath> = []
 
     override func prepare(forCollectionViewUpdates updateItems: [UICollectionViewUpdateItem]) {
         super.prepare(forCollectionViewUpdates: updateItems)
@@ -444,13 +446,24 @@ class TimeMachineCollectionViewLayout: UICollectionViewLayout {
         let mostRecentOffset = self.getMostRecentItemContentOffset() else { return }
 
         for update in updateItems {
-            if let indexPath = update.indexPathAfterUpdate, update.updateAction == .insert {
+            switch update.updateAction {
+            case .insert:
+                guard let indexPath = update.indexPathAfterUpdate else { break }
+                self.insertedIndexPaths.insert(indexPath)
+
+                let isScrolledToMostRecent = (mostRecentOffset.y - collectionView.contentOffset.y) <= self.itemHeight
                 // Always scroll to the end for new user messages, or if we're currently scrolled to the
                 // most recent message.
-                if indexPath.section == 1
-                    || (mostRecentOffset.y - collectionView.contentOffset.y) <= self.itemHeight {
+                if indexPath.section == 1 || isScrolledToMostRecent {
                     self.shouldScrollToEnd = true
                 }
+            case .delete:
+                guard let indexPath = update.indexPathBeforeUpdate else { break }
+                self.deletedIndexPaths.insert(indexPath)
+            case .reload, .move, .none:
+                break
+            @unknown default:
+                break
             }
         }
     }
@@ -459,6 +472,8 @@ class TimeMachineCollectionViewLayout: UICollectionViewLayout {
         super.finalizeCollectionViewUpdates()
 
         self.shouldScrollToEnd = false
+        self.deletedIndexPaths.removeAll()
+        self.insertedIndexPaths.removeAll()
     }
 
     override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint) -> CGPoint {
@@ -481,15 +496,24 @@ class TimeMachineCollectionViewLayout: UICollectionViewLayout {
 
     override func finalLayoutAttributesForDisappearingItem(at itemIndexPath: IndexPath)
     -> UICollectionViewLayoutAttributes? {
+        guard deletedIndexPaths.contains(itemIndexPath) else { return nil }
 
-        var attributes = super.finalLayoutAttributesForDisappearingItem(at: itemIndexPath)
-        if itemIndexPath.section == 0 {
-            // HACK: Items are incorrectly both disappearing and appearing. The disappearing animation
-            // sometimes makes it appear that an item is duplicated and moving in two different directions.
-            // To get around this, make the disappearing item move to the exact same place as
-            // the appearing version.
-            attributes = self.initialLayoutAttributesForAppearingItem(at: itemIndexPath)
+        return super.finalLayoutAttributesForDisappearingItem(at: itemIndexPath)
+    }
+
+    override func initialLayoutAttributesForAppearingItem(at itemIndexPath: IndexPath)
+    -> UICollectionViewLayoutAttributes? {
+
+        let attributes = super.initialLayoutAttributesForAppearingItem(at: itemIndexPath)
+
+        guard itemIndexPath.section == 1 else {
             return attributes
+        }
+
+        // A new message dropped in the user's message stack should appear immediately.
+        if self.insertedIndexPaths.contains(itemIndexPath)
+            && self.dataSource?.getMessage(forItemAt: itemIndexPath) != nil {
+            attributes?.alpha = 1
         }
 
         return attributes

--- a/iOS/Flows/Conversation/Cells/TimeMachineCollectionViewLayout.swift
+++ b/iOS/Flows/Conversation/Cells/TimeMachineCollectionViewLayout.swift
@@ -511,6 +511,7 @@ class TimeMachineCollectionViewLayout: UICollectionViewLayout {
             return attributes
         }
 
+        // Ensure this is actually a new message and not just a placeholder message.
         if self.insertedIndexPaths.contains(itemIndexPath)
             && self.dataSource?.getMessage(forItemAt: itemIndexPath) != nil {
             attributes?.alpha = 1

--- a/iOS/Flows/Conversation/Cells/TimeMachineCollectionViewLayout.swift
+++ b/iOS/Flows/Conversation/Cells/TimeMachineCollectionViewLayout.swift
@@ -506,11 +506,11 @@ class TimeMachineCollectionViewLayout: UICollectionViewLayout {
 
         let attributes = super.initialLayoutAttributesForAppearingItem(at: itemIndexPath)
 
+        // A new message dropped in the user's message stack should appear immediately.
         guard itemIndexPath.section == 1 else {
             return attributes
         }
 
-        // A new message dropped in the user's message stack should appear immediately.
         if self.insertedIndexPaths.contains(itemIndexPath)
             && self.dataSource?.getMessage(forItemAt: itemIndexPath) != nil {
             attributes?.alpha = 1


### PR DESCRIPTION
I removed the hack and replaced it with a better approach.
Turns out the appear and disappear get called on all visible cells whenever there's an update. There's nothing I can do about it. It even happens in Apple's flow layout.

So whenever there are updates, I keep track of what's actually being deleted. I'll only apply animations to items that are actually being deleted.

ALSO, I improved the drag and drop so that the message appears immediately as seen here:

https://user-images.githubusercontent.com/88675954/144521728-b0cc80a3-29d1-4a2e-9961-76385c242525.mp4


