### PR TITLE
Turning off parse websocket logging.

### DIFF
--- a/Shared/Stores/ConnectionStore.swift
+++ b/Shared/Stores/ConnectionStore.swift
@@ -53,8 +53,9 @@ class ConnectionStore {
     private func subscibeToUpdates() {
         self.isReady = true
 
-        self.queries.forEach { query in
+        Client.shared.shouldPrintWebSocketLog = false
 
+        self.queries.forEach { query in
             let subscription = Client.shared.subscribe(query)
 
             subscription.handleEvent { query, event in


### PR DESCRIPTION
This silences those periodic parse live query warnings. 

I assume those warnings are harmless, but let me know if you think otherwise.