### PR TITLE
Martin/message send animation fix

### DIFF
--- a/iOS/Flows/Conversation/Cells/TimeMachineCollectionViewLayout.swift
+++ b/iOS/Flows/Conversation/Cells/TimeMachineCollectionViewLayout.swift
@@ -476,9 +476,23 @@ class TimeMachineCollectionViewLayout: UICollectionViewLayout {
             return modifiedAttributes
         }
 
-        attributes?.center.y += self.zPositionBeforeAnimation - self.zPosition
+        // Items being inserted
+        let normalizedZOffset: CGFloat
+        if itemIndexPath.item == self.numberOfItems(inSection: itemIndexPath.section) - 1 {
+            if itemIndexPath.section == 0 {
+                normalizedZOffset = 1
+            } else {
+                normalizedZOffset = 0
+            }
+        } else {
+            normalizedZOffset = -1
+        }
+        let modifiedAttributes = self.layoutAttributesForItemAt(indexPath: itemIndexPath,
+                                                                withNormalizedZOffset: normalizedZOffset)
 
-        return attributes
+        modifiedAttributes?.center.y += self.zPositionBeforeAnimation - self.zPosition
+
+        return modifiedAttributes
     }
 
     override func finalizeCollectionViewUpdates() {

--- a/iOS/Flows/Conversation/Cells/TimeMachineCollectionViewLayout.swift
+++ b/iOS/Flows/Conversation/Cells/TimeMachineCollectionViewLayout.swift
@@ -476,20 +476,9 @@ class TimeMachineCollectionViewLayout: UICollectionViewLayout {
             return modifiedAttributes
         }
 
-        // Items being inserted
-        var normalizedZOffset = self.getNormalizedZOffsetForItem(at: itemIndexPath,
-                                                                 givenZPosition: self.zPosition)
-        if normalizedZOffset <= 0 {
-            normalizedZOffset = -1
-        } else {
-            normalizedZOffset = 1
-        }
-        let modifiedAttributes = self.layoutAttributesForItemAt(indexPath: itemIndexPath,
-                                                                withNormalizedZOffset: normalizedZOffset)
+        attributes?.center.y += self.zPositionBeforeAnimation - self.zPosition
 
-        modifiedAttributes?.center.y += self.zPositionBeforeAnimation - self.zPosition
-
-        return modifiedAttributes
+        return attributes
     }
 
     override func finalizeCollectionViewUpdates() {


### PR DESCRIPTION
When your messages are sent, they appear immediately again. I accidentally made them scale up a couple weeks ago.

Newly received messages will start big and scale down as expected.

Loaded messages come in from the distance, and scale up.

https://user-images.githubusercontent.com/88675954/153928357-9e3590ba-e856-43e8-9774-ce9b7fca4ff5.mp4

