### PR TITLE
Adding a staging app group.

### DIFF
--- a/Intents Extension/Intent Handlers/FocusIntentHandler.swift
+++ b/Intents Extension/Intent Handlers/FocusIntentHandler.swift
@@ -26,7 +26,7 @@ class FocusIntentHandler: NSObject, INShareFocusStatusIntentHandling {
         if Parse.currentConfiguration == nil  {
             let config = ParseClientConfiguration { configuration in
                 configuration.applicationGroupIdentifier = Config.shared.environment.groupId
-                configuration.containingApplicationBundleIdentifier = "com.Jibber-Inc.iOS"
+                configuration.containingApplicationBundleIdentifier = Config.shared.environment.bundleId
                 configuration.server = Config.shared.environment.url
                 configuration.applicationId = Config.shared.environment.appId
                 configuration.isLocalDatastoreEnabled = true

--- a/Intents Extension/Intents Extension.entitlements
+++ b/Intents Extension/Intents Extension.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.Jibber</string>
+		<string>group.Jibber-staging</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>

--- a/Intents ExtensionUI/Intents ExtensionUI.entitlements
+++ b/Intents ExtensionUI/Intents ExtensionUI.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.Jibber</string>
+		<string>group.Jibber-staging</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>

--- a/Notification Content/NotificationContent.entitlements
+++ b/Notification Content/NotificationContent.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.Jibber</string>
+		<string>group.Jibber-staging</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>

--- a/Notification Content/NotificationViewController.swift
+++ b/Notification Content/NotificationViewController.swift
@@ -30,7 +30,7 @@ class NotificationViewController: UIViewController, UNNotificationContentExtensi
         if Parse.currentConfiguration == nil  {
             Parse.initialize(with: ParseClientConfiguration(block: { (configuration: ParseMutableClientConfiguration) -> Void in
                 configuration.applicationGroupIdentifier = Config.shared.environment.groupId
-                configuration.containingApplicationBundleIdentifier = "com.Jibber-Inc.iOS"
+                configuration.containingApplicationBundleIdentifier = Config.shared.environment.bundleId
                 configuration.server = Config.shared.environment.url
                 configuration.applicationId = Config.shared.environment.appId
                 configuration.isLocalDatastoreEnabled = true

--- a/Notification Service/NotificationService.entitlements
+++ b/Notification Service/NotificationService.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.Jibber</string>
+		<string>group.Jibber-staging</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>

--- a/Notification Service/NotificationService.swift
+++ b/Notification Service/NotificationService.swift
@@ -81,7 +81,7 @@ class NotificationService: UNNotificationServiceExtension {
                 let config = ParseClientConfiguration { configuration in
                     configuration.applicationGroupIdentifier = Config.shared.environment.groupId
                     // Allow parse to access the data from the main app bundle.
-                    configuration.containingApplicationBundleIdentifier = "com.Jibber-Inc.iOS"
+                    configuration.containingApplicationBundleIdentifier = Config.shared.environment.bundleId
                     configuration.server = Config.shared.environment.url
                     configuration.applicationId = Config.shared.environment.appId
                     configuration.isLocalDatastoreEnabled = true

--- a/Shared/API/Config.swift
+++ b/Shared/API/Config.swift
@@ -27,6 +27,15 @@ enum Environment: String {
         }
     }
 
+    var bundleId: String {
+        switch self {
+        case .staging:
+            return "com.Jibber-Inc.iOS-staging"
+        case .production:
+            return "com.Jibber-Inc.iOS"
+        }
+    }
+
     var displayName: String {
         switch self {
         case .staging: return "stag"
@@ -35,7 +44,12 @@ enum Environment: String {
     }
 
     var groupId: String {
-        return "group.Jibber"
+        switch self {
+        case .staging:
+            return "group.Jibber-staging"
+        case .production:
+            return "group.Jibber"
+        }
     }
 
     var chatAPIKey: String {

--- a/iOS/Jibber.entitlements
+++ b/iOS/Jibber.entitlements
@@ -24,6 +24,7 @@
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.Jibber</string>
+		<string>group.Jibber-staging</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>


### PR DESCRIPTION
This should keep parse data separated between the staging and prod environments. 