### PR TITLE
Benji/ios 628 test unread message notice

### DIFF
--- a/Shared/Stores/NoticeStore.swift
+++ b/Shared/Stores/NoticeStore.swift
@@ -42,12 +42,9 @@ class NoticeStore {
             throw error
         }
     }
-    
+        
     func getAllNotices() async -> [SystemNotice] {
         let existing = self.allNotices
-            .filter({ notice in
-                notice.type != .unreadMessages
-            })
             .compactMap { notice in
             return SystemNotice(with: notice)
         }.sorted()

--- a/iOS/Flows/Profile/User Conversation List/ConversationCell.swift
+++ b/iOS/Flows/Profile/User Conversation List/ConversationCell.swift
@@ -154,6 +154,11 @@ class ConversationCell: CollectionViewManagerCell, ManageableCell {
             .messagesChangesPublisher
             .mainSink { [unowned self] changes in
                 guard let conversationController = self.conversationController else { return }
+                if let latest = conversationController.channel?.latestMessages.first(where: { message in
+                    return !message.isDeleted
+                }) {
+                    self.update(for: latest)
+                }
                 self.setNumberOfUnread(value: conversationController.conversation.totalUnread)
             }.store(in: &self.subscriptions)
     }

--- a/iOS/Flows/Profile/User Conversation List/ConversationCell.swift
+++ b/iOS/Flows/Profile/User Conversation List/ConversationCell.swift
@@ -152,6 +152,25 @@ class ConversationCell: CollectionViewManagerCell, ManageableCell {
         }
         
         self.conversationController?
+            .memberEventPublisher
+            .mainSink(receiveValue: { [unowned self] event in
+                guard let conversationController = self.conversationController else {
+                    return
+                }
+                switch event {
+                case _ as MemberAddedEvent, _ as MemberRemovedEvent:
+                    let members = conversationController.conversation.lastActiveMembers.filter { member in
+                        return member.personId != ChatClient.shared.currentUserId
+                    }
+                    
+                    self.stackedAvatarView.configure(with: members)
+                default:
+                    break
+                }
+                
+            }).store(in: &self.subscriptions)
+        
+        self.conversationController?
             .channelChangePublisher
             .mainSink(receiveValue: { [unowned self] _ in
                 guard let conversationController = self.conversationController else { return }
@@ -161,6 +180,9 @@ class ConversationCell: CollectionViewManagerCell, ManageableCell {
                     self.update(for: latest)
                 }
                 self.setNumberOfUnread(value: conversationController.conversation.totalUnread)
+                
+                
+                
             }).store(in: &self.subscriptions)
         
         self.conversationController?

--- a/iOS/Flows/Profile/User Conversation List/ConversationCell.swift
+++ b/iOS/Flows/Profile/User Conversation List/ConversationCell.swift
@@ -150,9 +150,22 @@ class ConversationCell: CollectionViewManagerCell, ManageableCell {
         self.subscriptions.forEach { cancellable in
             cancellable.cancel()
         }
+        
+        self.conversationController?
+            .channelChangePublisher
+            .mainSink(receiveValue: { [unowned self] _ in
+                guard let conversationController = self.conversationController else { return }
+                if let latest = conversationController.channel?.latestMessages.first(where: { message in
+                    return !message.isDeleted
+                }) {
+                    self.update(for: latest)
+                }
+                self.setNumberOfUnread(value: conversationController.conversation.totalUnread)
+            }).store(in: &self.subscriptions)
+        
         self.conversationController?
             .messagesChangesPublisher
-            .mainSink { [unowned self] changes in
+            .mainSink { [unowned self] _ in
                 guard let conversationController = self.conversationController else { return }
                 if let latest = conversationController.channel?.latestMessages.first(where: { message in
                     return !message.isDeleted

--- a/iOS/Flows/Profile/User Conversation List/UnreadMessagesCell.swift
+++ b/iOS/Flows/Profile/User Conversation List/UnreadMessagesCell.swift
@@ -131,6 +131,19 @@ class UnreadMessagesCell: CollectionViewManagerCell, ManageableCell {
         self.subscriptions.forEach { cancellable in
             cancellable.cancel()
         }
+        
+        self.conversationController?
+            .channelChangePublisher
+            .mainSink(receiveValue: { [unowned self] _ in
+                guard let conversationController = self.conversationController else { return }
+                if let latest = conversationController.channel?.latestMessages.first(where: { message in
+                    return !message.isDeleted
+                }) {
+                    self.update(for: latest)
+                }
+                self.setNumberOfUnread(value: conversationController.conversation.totalUnread)
+            }).store(in: &self.subscriptions)
+        
         self.conversationController?
             .messagesChangesPublisher
             .mainSink { [unowned self] changes in

--- a/iOS/Flows/Profile/User Conversation List/UnreadMessagesCell.swift
+++ b/iOS/Flows/Profile/User Conversation List/UnreadMessagesCell.swift
@@ -135,6 +135,11 @@ class UnreadMessagesCell: CollectionViewManagerCell, ManageableCell {
             .messagesChangesPublisher
             .mainSink { [unowned self] changes in
                 guard let conversationController = self.conversationController else { return }
+                if let latest = conversationController.channel?.latestMessages.first(where: { message in
+                    return !message.isDeleted
+                }) {
+                    self.update(for: latest)
+                }
                 self.setNumberOfUnread(value: conversationController.conversation.totalUnread)
             }.store(in: &self.subscriptions)
     }

--- a/iOS/Flows/Room/RoomViewController.swift
+++ b/iOS/Flows/Room/RoomViewController.swift
@@ -114,7 +114,9 @@ class RoomViewController: DiffableCollectionViewController<RoomSectionType,
         var data: [RoomSectionType: [RoomItemType]] = [:]
         
         try? await NoticeStore.shared.initializeIfNeeded()
-        let notices = await NoticeStore.shared.getAllNotices()
+        let notices = await NoticeStore.shared.getAllNotices().filter({ notice in
+            return notice.type != .unreadMessages
+        })
         
         data[.notices] = notices.compactMap({ notice in
             return .notice(notice)
@@ -143,9 +145,12 @@ class RoomViewController: DiffableCollectionViewController<RoomSectionType,
     func reloadNotices() async {
         
         try? await NoticeStore.shared.initializeIfNeeded()
-        let notices = await NoticeStore.shared.getAllNotices()
+        let notices = await NoticeStore.shared.getAllNotices().filter({ notice in
+            return notice.type != .unreadMessages
+        })
         
-        var items: [RoomItemType] = notices.compactMap({ notice in
+        var items: [RoomItemType] = notices
+            .compactMap({ notice in
             return .notice(notice)
         })
         


### PR DESCRIPTION
I discovered the issues with the UNREAD_MESSAGES notice were more to do with the backend. Basically there was a missing Notice because it never created one for accounts, due to our accounts already existing AND when I created them the attributes required a key of "unreadMessages" in order to populate it with values. 

However this exercise did lead me to find some other nice updates. Not the conversation cells will update whenever the messages, members, or channel changes. 