### PR TITLE
Martin/ios 687 load selected conversation first

### DIFF
--- a/Jibber.xcodeproj/project.pbxproj
+++ b/Jibber.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 		8023C6A227EBCDEF00FD9DB6 /* MediaViewerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8023C6A127EBCDEF00FD9DB6 /* MediaViewerCoordinator.swift */; };
 		8024B95326F278C8008ABF7F /* ConversationListCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8024B95026F278C8008ABF7F /* ConversationListCollectionViewDataSource.swift */; };
 		80251FF826F3D362006D7873 /* MessageController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80251FF726F3D362006D7873 /* MessageController+Extensions.swift */; };
-		8028C9E9273ECB1200520465 /* ConversationListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8028C9E8273ECB1200520465 /* ConversationListViewController.swift */; };
+		8028C9E9273ECB1200520465 /* ConversationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8028C9E8273ECB1200520465 /* ConversationViewController.swift */; };
 		802C448A26CC76CC00A333A4 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802C448926CC76CC00A333A4 /* Logger.swift */; };
 		802C448C26CC76CC00A333A4 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802C448926CC76CC00A333A4 /* Logger.swift */; };
 		802EDDAB27ECD496005ECA9C /* String+DataTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802EDDAA27ECD496005ECA9C /* String+DataTypes.swift */; };
@@ -689,7 +689,7 @@
 		D67896B422FF75640059BA75 /* OnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67896B322FF75640059BA75 /* OnboardingCoordinator.swift */; };
 		D67896BD23025FEC0059BA75 /* NameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67896BC23025FEC0059BA75 /* NameViewController.swift */; };
 		D67896BF2302683C0059BA75 /* ProfilePhotoCaptureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67896BE2302683C0059BA75 /* ProfilePhotoCaptureViewController.swift */; };
-		D67896CC2304524C0059BA75 /* ConversationListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67896CB2304524C0059BA75 /* ConversationListCoordinator.swift */; };
+		D67896CC2304524C0059BA75 /* ConversationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67896CB2304524C0059BA75 /* ConversationCoordinator.swift */; };
 		D678EC2426F530850071DB0D /* Circle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D678EC2326F530850071DB0D /* Circle.swift */; };
 		D6792CE525FBE87600B6575C /* CAGradientLayer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6792CE425FBE87600B6575C /* CAGradientLayer+Extensions.swift */; };
 		D6792CE725FBE87600B6575C /* CAGradientLayer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6792CE425FBE87600B6575C /* CAGradientLayer+Extensions.swift */; };
@@ -892,7 +892,7 @@
 		D6DD0C3B2822F3DE004999F2 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = D6DD0C3A2822F3DE004999F2 /* Sentry */; };
 		D6DEC3ED27A1D9520072D9D0 /* RoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DEC3EC27A1D9520072D9D0 /* RoomViewController.swift */; };
 		D6DEC3EF27A1DA5D0072D9D0 /* RoomCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DEC3EE27A1DA5D0072D9D0 /* RoomCoordinator.swift */; };
-		D6DEC40027A2213E0072D9D0 /* ConversationListCoordinator+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DEC3FF27A2213E0072D9D0 /* ConversationListCoordinator+Presentation.swift */; };
+		D6DEC40027A2213E0072D9D0 /* ConversationCoordinator+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DEC3FF27A2213E0072D9D0 /* ConversationCoordinator+Presentation.swift */; };
 		D6DEC40227A22F540072D9D0 /* RoomMemberCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DEC40127A22F540072D9D0 /* RoomMemberCell.swift */; };
 		D6DEC40427A22F660072D9D0 /* RoomCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DEC40327A22F660072D9D0 /* RoomCollectionViewDataSource.swift */; };
 		D6DEC40627A22F790072D9D0 /* RoomCollectionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DEC40527A22F790072D9D0 /* RoomCollectionViewLayout.swift */; };
@@ -1013,7 +1013,7 @@
 		8023C6A127EBCDEF00FD9DB6 /* MediaViewerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViewerCoordinator.swift; sourceTree = "<group>"; };
 		8024B95026F278C8008ABF7F /* ConversationListCollectionViewDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationListCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		80251FF726F3D362006D7873 /* MessageController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessageController+Extensions.swift"; sourceTree = "<group>"; };
-		8028C9E8273ECB1200520465 /* ConversationListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListViewController.swift; sourceTree = "<group>"; };
+		8028C9E8273ECB1200520465 /* ConversationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationViewController.swift; sourceTree = "<group>"; };
 		802C448926CC76CC00A333A4 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		802EDDAA27ECD496005ECA9C /* String+DataTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+DataTypes.swift"; sourceTree = "<group>"; };
 		80395ACB275A8A47004BE466 /* MessagesTimeMachineCollectionViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesTimeMachineCollectionViewLayout.swift; sourceTree = "<group>"; };
@@ -1319,7 +1319,7 @@
 		D67896B322FF75640059BA75 /* OnboardingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCoordinator.swift; sourceTree = "<group>"; };
 		D67896BC23025FEC0059BA75 /* NameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameViewController.swift; sourceTree = "<group>"; };
 		D67896BE2302683C0059BA75 /* ProfilePhotoCaptureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePhotoCaptureViewController.swift; sourceTree = "<group>"; };
-		D67896CB2304524C0059BA75 /* ConversationListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListCoordinator.swift; sourceTree = "<group>"; };
+		D67896CB2304524C0059BA75 /* ConversationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationCoordinator.swift; sourceTree = "<group>"; };
 		D678EC2326F530850071DB0D /* Circle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Circle.swift; sourceTree = "<group>"; };
 		D6792CE425FBE87600B6575C /* CAGradientLayer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CAGradientLayer+Extensions.swift"; sourceTree = "<group>"; };
 		D67934DA23DC011D00536B44 /* CharacterCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterCountView.swift; sourceTree = "<group>"; };
@@ -1431,7 +1431,7 @@
 		D6DA3191259B5B6D0078E769 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		D6DEC3EC27A1D9520072D9D0 /* RoomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomViewController.swift; sourceTree = "<group>"; };
 		D6DEC3EE27A1DA5D0072D9D0 /* RoomCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCoordinator.swift; sourceTree = "<group>"; };
-		D6DEC3FF27A2213E0072D9D0 /* ConversationListCoordinator+Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationListCoordinator+Presentation.swift"; sourceTree = "<group>"; };
+		D6DEC3FF27A2213E0072D9D0 /* ConversationCoordinator+Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationCoordinator+Presentation.swift"; sourceTree = "<group>"; };
 		D6DEC40127A22F540072D9D0 /* RoomMemberCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMemberCell.swift; sourceTree = "<group>"; };
 		D6DEC40327A22F660072D9D0 /* RoomCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		D6DEC40527A22F790072D9D0 /* RoomCollectionViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCollectionViewLayout.swift; sourceTree = "<group>"; };
@@ -1551,12 +1551,12 @@
 			isa = PBXGroup;
 			children = (
 				80BF68B0278D351600BFE828 /* ConversationCollectionView.swift */,
+				D67896CB2304524C0059BA75 /* ConversationCoordinator.swift */,
+				D6DEC3FF27A2213E0072D9D0 /* ConversationCoordinator+Presentation.swift */,
 				8098CC60270F8A2300636484 /* ConversationListCollectionView.swift */,
 				8024B95026F278C8008ABF7F /* ConversationListCollectionViewDataSource.swift */,
 				80D7721A26F93B17009F0344 /* ConversationListCollectionViewLayout.swift */,
-				D67896CB2304524C0059BA75 /* ConversationListCoordinator.swift */,
-				D6DEC3FF27A2213E0072D9D0 /* ConversationListCoordinator+Presentation.swift */,
-				8028C9E8273ECB1200520465 /* ConversationListViewController.swift */,
+				8028C9E8273ECB1200520465 /* ConversationViewController.swift */,
 				809EDC6B273ECEF000597473 /* ConversationListViewController+Extensions.swift */,
 				D682F030278E47930016A24E /* ConversationsMessagesCellAttributes.swift */,
 			);
@@ -3482,7 +3482,7 @@
 				D62D16322736F60400C542CE /* ToastStatusView.swift in Sources */,
 				D6E974362752C47F00D95F08 /* EmotionCategory.swift in Sources */,
 				D66F0FD222BF065F00BA277D /* DeeplinkTarget.swift in Sources */,
-				D6DEC40027A2213E0072D9D0 /* ConversationListCoordinator+Presentation.swift in Sources */,
+				D6DEC40027A2213E0072D9D0 /* ConversationCoordinator+Presentation.swift in Sources */,
 				D6EB4DF023540E48005BF3B4 /* FaceImageCaptureViewController.swift in Sources */,
 				D656BF0F281845B800723068 /* MessageDateLabel.swift in Sources */,
 				D671E1F526402B9800BF2B8D /* ToastScheduler.swift in Sources */,
@@ -3544,7 +3544,7 @@
 				D61EC0F121D313F500204BEE /* ScreenSize.swift in Sources */,
 				80C72A95275EBE4B006A69EC /* SwipeableInputAccessoryMessageSender.swift in Sources */,
 				D60B885827F2447600B3E1C2 /* MessageReadCell.swift in Sources */,
-				D67896CC2304524C0059BA75 /* ConversationListCoordinator.swift in Sources */,
+				D67896CC2304524C0059BA75 /* ConversationCoordinator.swift in Sources */,
 				D61EC0E821D3107A00204BEE /* Date+Extensions.swift in Sources */,
 				D6F4602F27FE364E00B48973 /* MiniBadgeView.swift in Sources */,
 				D6619E582808BFA3004151CE /* PinnedMessageCell.swift in Sources */,
@@ -3695,7 +3695,7 @@
 				D60B886927F5026700B3E1C2 /* TypingIndicatorView.swift in Sources */,
 				D657A35827FB4F7900664DD3 /* EmptyUnreadMessageCell.swift in Sources */,
 				D61A33CF27D4F28800056242 /* EmojiCollectionView.swift in Sources */,
-				8028C9E9273ECB1200520465 /* ConversationListViewController.swift in Sources */,
+				8028C9E9273ECB1200520465 /* ConversationViewController.swift in Sources */,
 				D6D557FE27C9B8AE0024D1CD /* UserConversationsCollectionView.swift in Sources */,
 				D66A580525DD68F9001B3F64 /* PeopleCoordinator.swift in Sources */,
 				8059AD4C27851162004330DC /* ChatUser+Extensions.swift in Sources */,

--- a/Shared/UI/Transitions/DismissTransitionController.swift
+++ b/Shared/UI/Transitions/DismissTransitionController.swift
@@ -56,8 +56,8 @@ class DismissTransitionController: NSObject, UIViewControllerAnimatedTransitioni
             toView = vc.messageContent
         } else if let rootVC = transitionContext.viewController(forKey: .to) as? RootNavigationController,
                   let listVC = rootVC.viewControllers.first(where: { controller in
-                      return controller is ConversationListViewController
-                  }) as? ConversationListViewController {
+                      return controller is ConversationViewController
+                  }) as? ConversationViewController {
             toVC = listVC
             toView = listVC.messageContent
         }

--- a/iOS/Flows/Conversation/Cells/ConversationMessagesCell.swift
+++ b/iOS/Flows/Conversation/Cells/ConversationMessagesCell.swift
@@ -27,6 +27,7 @@ class ConversationMessagesCell: UICollectionViewCell, ConversationUIStateSettabl
         set { self.dataSource.messageContentDelegate = newValue }
     }
     var handleCollectionViewTapped: CompletionOptional = nil
+    var handleAddMembersTapped: CompletionOptional = nil
     
     // Collection View
 
@@ -73,6 +74,10 @@ class ConversationMessagesCell: UICollectionViewCell, ConversationUIStateSettabl
 
         self.dataSource.handleLoadMoreMessages = { [unowned self] cid in
             self.conversationController?.loadPreviousMessages()
+        }
+
+        self.dataSource.handleAddMembers = { [unowned self] in
+            self.handleAddMembersTapped?()
         }
     }
 

--- a/iOS/Flows/Conversation/Cells/MessageSequenceCollectionViewDataSource.swift
+++ b/iOS/Flows/Conversation/Cells/MessageSequenceCollectionViewDataSource.swift
@@ -33,6 +33,7 @@ class MessageSequenceCollectionViewDataSource: CollectionViewDataSource<MessageS
     // Input handling
     weak var messageContentDelegate: MessageContentDelegate?
     var handleLoadMoreMessages: ((ConversationId) -> Void)?
+    var handleAddMembers: CompletionOptional = nil
 
     /// If true, show the replies for each message
     var shouldShowReplies: Bool {
@@ -94,6 +95,9 @@ class MessageSequenceCollectionViewDataSource: CollectionViewDataSource<MessageS
                                                                     for: indexPath,
                                                                     item: (self.messageSequenceController,
                                                                            collectionView))
+            cell.didTapAddMembers = { [unowned self] in
+                self.handleAddMembers?()
+            }
             return cell
         }
     }

--- a/iOS/Flows/Conversation/Conversation List/ConversationCollectionView.swift
+++ b/iOS/Flows/Conversation/Conversation List/ConversationCollectionView.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// A collection view that displays a single conversation.
 class ConversationCollectionView: CollectionView {
 
     var conversationLayout: MessagesTimeMachineCollectionViewLayout {

--- a/iOS/Flows/Conversation/Conversation List/ConversationCoordinator+Presentation.swift
+++ b/iOS/Flows/Conversation/Conversation List/ConversationCoordinator+Presentation.swift
@@ -48,7 +48,9 @@ extension ConversationCoordinator {
                                    startingReplyId: replyId)
             case .conversation(let conversation):
                 Task.onMainActorAsync {
-                    await self.listVC.scrollToConversation(with: conversation, messageId: nil, animateScroll: false)
+                    await self.listVC.scrollToConversation(with: conversation,
+                                                           messageId: nil,
+                                                           animateScroll: false)
                 }
             case .none:
                 break

--- a/iOS/Flows/Conversation/Conversation List/ConversationCoordinator+Presentation.swift
+++ b/iOS/Flows/Conversation/Conversation List/ConversationCoordinator+Presentation.swift
@@ -1,5 +1,5 @@
 //
-//  ConversationListCoordinator+Presentation.swift
+//  ConversationCoordinator+Presentation.swift
 //  Jibber
 //
 //  Created by Benji Dodgson on 1/26/22.
@@ -11,7 +11,7 @@ import StreamChat
 import Localization
 import Photos
 
-extension ConversationListCoordinator {
+extension ConversationCoordinator {
         
     func presentThread(for cid: ConversationId,
                        messageId: MessageId,

--- a/iOS/Flows/Conversation/Conversation List/ConversationCoordinator.swift
+++ b/iOS/Flows/Conversation/Conversation List/ConversationCoordinator.swift
@@ -14,27 +14,26 @@ import StreamChat
 import Localization
 import Intents
 
-class ConversationListCoordinator: InputHandlerCoordinator<Void>, DeepLinkHandler {
+/// A coordinator for displaying a single conversation.
+class ConversationCoordinator: InputHandlerCoordinator<Void>, DeepLinkHandler {
     
-    var listVC: ConversationListViewController {
-        return self.inputHandlerViewController as! ConversationListViewController
+    var listVC: ConversationViewController {
+        return self.inputHandlerViewController as! ConversationViewController
     }
     
     init(router: Router,
          deepLink: DeepLinkable?,
-         conversationMembers: [ConversationMember],
-         startingConversationId: ConversationId?,
+         cid: ConversationId,
          startingMessageId: MessageId?,
          openReplies: Bool = false) {
         
-        let vc = ConversationListViewController(members: conversationMembers,
-                                                startingConversationID: startingConversationId,
-                                                startingMessageID: startingMessageId,
-                                                openReplies: openReplies)
-
+        let vc = ConversationViewController(cid: cid,
+                                            startingMessageID: startingMessageId,
+                                            openReplies: openReplies)
+        
         super.init(with: vc, router: router, deepLink: deepLink)
     }
-
+    
     override func start() {
         super.start()
         
@@ -63,12 +62,12 @@ class ConversationListCoordinator: InputHandlerCoordinator<Void>, DeepLinkHandle
             self.presentEmailAlert() 
         }
     }
-
+    
     func handle(deepLink: DeepLinkable) {
         self.deepLink = deepLink
-
+        
         guard let target = deepLink.deepLinkTarget else { return }
-
+        
         switch target {
         case .conversation:
             let messageID = deepLink.messageId
@@ -133,9 +132,9 @@ class ConversationListCoordinator: InputHandlerCoordinator<Void>, DeepLinkHandle
     
     override func messageContent(_ content: MessageContentView,
                                  didTapMessage messageInfo: (ConversationId, MessageId)) {
-
+        
         let message = Message.message(with: messageInfo.0, messageId: messageInfo.1)
-
+        
         if let parentId = message.parentMessageId {
             self.presentThread(for: messageInfo.0, messageId: parentId, startingReplyId: messageInfo.1)
         } else {
@@ -150,7 +149,7 @@ class ConversationListCoordinator: InputHandlerCoordinator<Void>, DeepLinkHandle
     }
 }
 
-extension ConversationListCoordinator: LaunchActivityHandler {
+extension ConversationCoordinator: LaunchActivityHandler {
     func handle(launchActivity: LaunchActivity) {
         switch launchActivity {
         case .onboarding(let phoneNumber):

--- a/iOS/Flows/Conversation/Conversation List/ConversationCoordinator.swift
+++ b/iOS/Flows/Conversation/Conversation List/ConversationCoordinator.swift
@@ -50,12 +50,7 @@ class ConversationCoordinator: InputHandlerCoordinator<Void>, DeepLinkHandler {
         }
         
         self.listVC.dataSource.handleAddPeopleSelected = { [unowned self] in
-            Task {
-                try await self.createNewConversation()
-                Task.onMainActor {
-                    self.presentPeoplePicker()
-                }
-            }
+            self.presentPeoplePicker()
         }
         
         self.listVC.dataSource.handleInvestmentSelected = { [unowned self] in

--- a/iOS/Flows/Conversation/Conversation List/ConversationListCollectionViewDataSource.swift
+++ b/iOS/Flows/Conversation/Conversation List/ConversationListCollectionViewDataSource.swift
@@ -135,14 +135,6 @@ class ConversationListCollectionViewDataSource: CollectionViewDataSource<Convers
             updatedItems.append(.loadMore)
         }
         updatedItems.append(contentsOf: conversationListController.conversations.asConversationCollectionItems)
-        
-        if UserDefaultsManager.getBool(for: .shouldShowGroupsUpsell, defaultValue: true) {
-            updatedItems.append(.upsell)
-        }
-        
-        if UserDefaultsManager.getBool(for: .shouldShowInvestUpsell, defaultValue: true) {
-            updatedItems.append(.invest)
-        }
       
         snapshot.setItems(updatedItems, in: sectionID)
 

--- a/iOS/Flows/Conversation/Conversation List/ConversationListCollectionViewDataSource.swift
+++ b/iOS/Flows/Conversation/Conversation List/ConversationListCollectionViewDataSource.swift
@@ -70,6 +70,9 @@ class ConversationListCollectionViewDataSource: CollectionViewDataSource<Convers
             conversationCell.handleCollectionViewTapped = { [unowned self] in
                 self.handleCollectionViewTapped?()
             }
+            conversationCell.handleAddMembersTapped = { [unowned self] in
+                self.handleAddPeopleSelected?()
+            }
 
             return conversationCell
         case .loadMore:

--- a/iOS/Flows/Conversation/Conversation List/ConversationListViewController+Extensions.swift
+++ b/iOS/Flows/Conversation/Conversation List/ConversationListViewController+Extensions.swift
@@ -9,7 +9,7 @@
 import Foundation
 import StreamChat
 
-extension ConversationListViewController {
+extension ConversationViewController {
 
     func setupInputHandlers() {
         self.dataSource.handleDidTapClose = { [unowned self] item in

--- a/iOS/Flows/Conversation/Conversation List/ConversationViewController.swift
+++ b/iOS/Flows/Conversation/Conversation List/ConversationViewController.swift
@@ -20,7 +20,9 @@ enum ConversationUIState: String {
     }
 }
 
-class ConversationListViewController: InputHandlerViewContoller, ConversationListCollectionViewLayoutDelegate {
+/// A view controller for displaying a single conversation.
+class ConversationViewController: InputHandlerViewContoller,
+                                  ConversationListCollectionViewLayoutDelegate {
     
     override var analyticsIdentifier: String? {
         return "SCREEN_CONVERSATION_LIST"
@@ -66,33 +68,25 @@ class ConversationListViewController: InputHandlerViewContoller, ConversationLis
 
     @Published var state: ConversationUIState = .read
 
-    /// A list of conversation members used to filter conversations. We'll only show conversations with this exact set of members.
-    private let members: [ConversationMember]
-    /// The id of the conversation we should land on when this VC appears.
-    private let startingConversationID: ConversationId?
+    /// The id of the conversation this VC will display.
+    private let cid: ConversationId
     private let startingMessageID: MessageId?
+    #warning("add documentation")
     private let openReplies: Bool
 
-    init(members: [ConversationMember],
-         startingConversationID: ConversationId?,
+    init(cid: ConversationId,
          startingMessageID: MessageId?,
          openReplies: Bool) {
-        
-        self.openReplies = openReplies
-        self.members = members
-        self.startingConversationID = startingConversationID
+
+        self.cid = cid
         self.startingMessageID = startingMessageID
+        self.openReplies = openReplies
 
-        let filter: Filter<ChannelListFilterScope>
-        = members.isEmpty ? .containMembers(userIds: [User.current()!.objectId!]) : .containOnlyMembers(members)
+        let filter: Filter<ChannelListFilterScope> = .equal("cid", to: cid)
 
-        let query = ChannelListQuery(filter: .and([.equal("hidden", to: false), filter]),
-                                     sort: [Sorting(key: .createdAt, isAscending: true)],
-                                     pageSize: .channelsPageSize,
-                                     messagesLimit: .messagesPageSize)
+        let query = ChannelListQuery(filter: filter, messagesLimit: .messagesPageSize)
         
-        self.conversationListController
-        = ChatClient.shared.channelListController(query: query)
+        self.conversationListController = ChatClient.shared.channelListController(query: query)
 
         super.init()
     }
@@ -176,10 +170,9 @@ class ConversationListViewController: InputHandlerViewContoller, ConversationLis
 
         let snapshot = self.dataSource.updatedSnapshot(with: self.conversationListController)
 
-        // Automatically scroll to the latest conversation.
+        // Automatically scroll to the conversation.
         let startingIndexPath: IndexPath
-        if let startingConversationID = self.startingConversationID,
-           let conversationIndexPath = snapshot.indexPathOfItem(.conversation(startingConversationID)) {
+        if let conversationIndexPath = snapshot.indexPathOfItem(.conversation(cid)) {
             startingIndexPath = conversationIndexPath
         } else {
             startingIndexPath = IndexPath(item: clamp(conversations.count - 1, min: 0) , section: 0)
@@ -195,10 +188,9 @@ class ConversationListViewController: InputHandlerViewContoller, ConversationLis
                                     animationCycle: animationCycle)
 
         self.collectionView.animationView.stop()
-        guard let startingConversationID = self.startingConversationID else { return }
 
         Task {
-            await self.scrollToConversation(with: startingConversationID,
+            await self.scrollToConversation(with: self.cid,
                                             messageId: self.startingMessageID,
                                             viewReplies: self.openReplies)
         }.add(to: self.autocancelTaskPool)
@@ -354,7 +346,7 @@ class ConversationListViewController: InputHandlerViewContoller, ConversationLis
             }
         } else {
             ConversationsManager.shared.activeConversation = nil
-            ConversationsManager.shared.activeController = nil 
+            ConversationsManager.shared.activeController = nil
 
             self.messageInputController.updateSwipeHint(shouldPlay: true)
 
@@ -372,7 +364,7 @@ class ConversationListViewController: InputHandlerViewContoller, ConversationLis
 
 // MARK: - MessageSendingViewControllerType
 
-extension ConversationListViewController: MessageSendingViewControllerType {
+extension ConversationViewController: MessageSendingViewControllerType {
 
     func getCurrentMessageSequence() -> MessageSequence? {
         return self.getCurrentConversationController()?.conversation
@@ -393,7 +385,7 @@ extension ConversationListViewController: MessageSendingViewControllerType {
 
 // MARK: - TransitionableViewController
 
-extension ConversationListViewController: TransitionableViewController {
+extension ConversationViewController: TransitionableViewController {
 
     var presentationType: TransitionType {
         return .fadeOutIn
@@ -436,7 +428,7 @@ extension ConversationListViewController: TransitionableViewController {
     }
 }
 
-extension ConversationListViewController: MessageInteractableController {
+extension ConversationViewController: MessageInteractableController {
     
     var messageContent: MessageContentView {
         return self.getCentmostMessageCellContent()!

--- a/iOS/Flows/Conversation/Conversation List/ConversationViewController.swift
+++ b/iOS/Flows/Conversation/Conversation List/ConversationViewController.swift
@@ -71,7 +71,6 @@ class ConversationViewController: InputHandlerViewContoller,
     /// The id of the conversation this VC will display.
     private let cid: ConversationId
     private let startingMessageID: MessageId?
-    #warning("add documentation")
     private let openReplies: Bool
 
     init(cid: ConversationId,

--- a/iOS/Flows/Room/RoomCoordinator+Presentation.swift
+++ b/iOS/Flows/Room/RoomCoordinator+Presentation.swift
@@ -12,16 +12,15 @@ import Intents
 
 extension RoomCoordinator {
     
-    func presentConversation(with cid: ConversationId?,
+    func presentConversation(with cid: ConversationId,
                              messageId: MessageId?,
                              openReplies: Bool = false) {
         
-        let coordinator = ConversationListCoordinator(router: self.router,
-                                                      deepLink: self.deepLink,
-                                                      conversationMembers: [],
-                                                      startingConversationId: cid,
-                                                      startingMessageId: messageId,
-                                                      openReplies: openReplies)
+        let coordinator = ConversationCoordinator(router: self.router,
+                                                  deepLink: self.deepLink,
+                                                  cid: cid,
+                                                  startingMessageId: messageId,
+                                                  openReplies: openReplies)
         self.addChildAndStart(coordinator, finishedHandler: { [unowned self] (_) in
             self.router.popModule() 
         })
@@ -43,7 +42,6 @@ extension RoomCoordinator {
     }
     
     func presentWallet() {
-        
         self.removeChild()
 
         let coordinator = WalletCoordinator(router: self.router, deepLink: self.deepLink)

--- a/iOS/Flows/Room/RoomCoordinator+Presentation.swift
+++ b/iOS/Flows/Room/RoomCoordinator+Presentation.swift
@@ -40,7 +40,7 @@ extension RoomCoordinator {
         
         self.router.present(coordinator, source: self.roomVC)
     }
-    
+
     func presentWallet() {
         self.removeChild()
 

--- a/iOS/Flows/Room/RoomCoordinator.swift
+++ b/iOS/Flows/Room/RoomCoordinator.swift
@@ -55,7 +55,6 @@ class RoomCoordinator: PresentableCoordinator<Void>, DeepLinkHandler {
     }
     
     private func setupHandlers() {
-        
         self.roomVC.dataSource.messageContentDelegate = self 
         
         self.roomVC.headerView.jibImageView.didSelect { [unowned self] in
@@ -91,7 +90,9 @@ class RoomCoordinator: PresentableCoordinator<Void>, DeepLinkHandler {
             switch itemType {
             case .memberId(let personId):
                 Task {
-                    guard let person = await PeopleStore.shared.getPerson(withPersonId: personId) else { return }
+                    guard let person = await PeopleStore.shared.getPerson(withPersonId: personId) else {
+                        return
+                    }
                     self.presentProfile(for: person)
                 }
             case .conversation(let cid):
@@ -105,7 +106,7 @@ class RoomCoordinator: PresentableCoordinator<Void>, DeepLinkHandler {
             }
         }.store(in: &self.cancellables)
     }
-    
+
     func createNewConversation() async throws -> Conversation? {
         let username = User.current()?.initials ?? ""
         let channelId = ChannelId(type: .messaging, id: username+"-"+UUID().uuidString)
@@ -143,19 +144,24 @@ extension RoomCoordinator: LaunchActivityHandler {
 
 extension RoomCoordinator: MessageContentDelegate {
     
-    func messageContent(_ content: MessageContentView, didTapViewReplies messageInfo: (ConversationId, MessageId)) {
+    func messageContent(_ content: MessageContentView,
+                        didTapViewReplies messageInfo: (ConversationId, MessageId)) {
+
         self.presentConversation(with: messageInfo.0, messageId: messageInfo.1, openReplies: true)
     }
     
-    func messageContent(_ content: MessageContentView, didTapMessage messageInfo: (ConversationId, MessageId)) {
+    func messageContent(_ content: MessageContentView,
+                        didTapMessage messageInfo: (ConversationId, MessageId)) {
         
     }
     
-    func messageContent(_ content: MessageContentView, didTapEditMessage messageInfo: (ConversationId, MessageId)) {
+    func messageContent(_ content: MessageContentView,
+                        didTapEditMessage messageInfo: (ConversationId, MessageId)) {
         
     }
     
-    func messageContent(_ content: MessageContentView, didTapAttachmentForMessage messageInfo: (ConversationId, MessageId)) {
+    func messageContent(_ content: MessageContentView,
+                        didTapAttachmentForMessage messageInfo: (ConversationId, MessageId)) {
 
     }
 }

--- a/iOS/Flows/Room/RoomViewController.swift
+++ b/iOS/Flows/Room/RoomViewController.swift
@@ -307,8 +307,7 @@ class RoomViewController: DiffableCollectionViewController<RoomSectionType,
         self.loadConversationsTask = Task { [weak self] in
             guard let user = User.current() else { return }
             
-            var userIds: [String] = []
-            userIds.append(user.objectId!)
+            let userIds: [String] = [user.objectId!]
             
             let filter = Filter<ChannelListFilterScope>.containsAtLeastThese(userIds: userIds)
             let query = ChannelListQuery(filter: filter,


### PR DESCRIPTION
We now only display one conversation at a time. 
The add people and invest cells have been hidden.

You can more easily add people to a conversation by tapping the initial cell. See demo below

Uploading Add Person Demo-Medium-32k.mp4…