### PR TITLE
Fixing issue where expressions would sometimes not play.

### DIFF
--- a/Shared/UI/Views/ExpressionVideoView.swift
+++ b/Shared/UI/Views/ExpressionVideoView.swift
@@ -16,14 +16,14 @@ class ExpressionVideoView: VideoView {
             guard self.expression != oldValue else { return }
 
             self.videoURL = nil
-            self.updatePlayer(with: self.expression)
+            self.updatePlayer()
         }
     }
     
     /// The currently running task that loads the video url.
     private var loadTask: Task<Void, Never>?
     
-    private func updatePlayer(with expression: Expression?) {
+    private func updatePlayer() {
         self.loadTask?.cancel()
 
         guard let expression = self.expression else {

--- a/Shared/UI/Views/VideoView.swift
+++ b/Shared/UI/Views/VideoView.swift
@@ -38,7 +38,7 @@ class VideoView: BaseView {
         super.initializeSubviews()
         
         NotificationCenter.default.publisher(for: AVPlayer.rateDidChangeNotification)
-            .filter({ notification in
+            .filter({ [unowned self] notification in
                 if let player = notification.object as? AVPlayer,
                    player === self.playerLayer.player {
                     return true
@@ -97,7 +97,7 @@ class VideoView: BaseView {
             
             self?.looper = AVPlayerLooper(player: player, templateItem: videoItem)
             
-            if let `self` = self, self.shouldPlay {
+            if self?.shouldPlay == true {
                 player.playImmediately(atRate: 1.0)
             }
         }


### PR DESCRIPTION
It was due to a memory leak in the video view. Leaked video views kept looping an asset so future video views couldn't play it.