### PR TITLE
Adjusting the compression settings for the back camera to bring down file size

### DIFF
--- a/iOS/Flows/Home/Moments/Capture/MomentCaptureViewController.swift
+++ b/iOS/Flows/Home/Moments/Capture/MomentCaptureViewController.swift
@@ -108,8 +108,6 @@ class MomentCaptureViewController: PiPRecordingViewController {
     private func setupHandlers() {
         
         self.panGestureHandler.didFinish = { [unowned self] in
-            logDebug("Did finish")
-            
             Task {
                 guard let recording = self.recording else { return }
                 await self.confirmationView.uploadMoment(from: recording, caption: self.textView.text)

--- a/iOS/Flows/Home/Moments/Capture/PIP/PiPRecorder.swift
+++ b/iOS/Flows/Home/Moments/Capture/PIP/PiPRecorder.swift
@@ -35,13 +35,13 @@ class PiPRecorder {
     private var backVideoSettings: [String: Any]?
     private var audioSettings: [String: Any]?
     
-    let pixelBufferAttributes: [String: Any] = [ kCVPixelBufferPixelFormatTypeKey: kCVPixelFormatType_32BGRA,
-                                                           kCVPixelBufferWidthKey: 480,
-                                                          kCVPixelBufferHeightKey: 480,
-                                              kCVPixelBufferMetalCompatibilityKey: true] as [String: Any]
+    let pixelBufferAttributes: [String: Any] = [kCVPixelBufferPixelFormatTypeKey: kCVPixelFormatType_32BGRA,
+                                                          kCVPixelBufferWidthKey: 480,
+                                                         kCVPixelBufferHeightKey: 480,
+                                             kCVPixelBufferMetalCompatibilityKey: true] as [String: Any]
     
     private var pixelBufferAdaptor: AVAssetWriterInputPixelBufferAdaptor?
-        
+
     var didCapturePIPRecording: ((PiPRecording) -> Void)?
     
     @Published private(set) var isReadyToRecord: Bool = false

--- a/iOS/Flows/Home/Moments/Capture/PIP/PiPRecordingViewController.swift
+++ b/iOS/Flows/Home/Moments/Capture/PIP/PiPRecordingViewController.swift
@@ -10,6 +10,7 @@ import Foundation
 import AVFoundation
 import Vision
 import Speech
+import VideoToolbox
 
 class PiPRecordingViewController: ViewController, AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAudioDataOutputSampleBufferDelegate {
     
@@ -135,9 +136,15 @@ class PiPRecordingViewController: ViewController, AVCaptureVideoDataOutputSample
     // MARK: - PUBLIC
     
     func startRecording() {
-        let settings = self.backOutput.recommendedVideoSettingsForAssetWriter(writingTo: .mp4)
-        let audioSettings = self.micDataOutput.recommendedAudioSettingsForAssetWriter(writingTo: .mp4)
-        self.recorder.initialize(backVideoSettings: settings, audioSettings: audioSettings)
+        var backVideoSettings = self.backOutput.recommendedVideoSettingsForAssetWriter(writingTo: .mov)
+        // Adjust the bitrate for change video size (less bitrate, less size and quality)
+        // This bitrate will need to be adjusted for videos that are higher res than 1080.
+        var compressionSettings = backVideoSettings?[AVVideoCompressionPropertiesKey] as! [String : Any]
+        compressionSettings[AVVideoAverageBitRateKey] = NSNumber(integerLiteral: 3_500_000)
+        backVideoSettings?[AVVideoCompressionPropertiesKey] = compressionSettings
+
+        let audioSettings = self.micDataOutput.recommendedAudioSettingsForAssetWriter(writingTo: .mov)
+        self.recorder.initialize(backVideoSettings: backVideoSettings, audioSettings: audioSettings)
         self.state = .recording
         self.selectionImpact.impactOccurred(intensity: 1.0)
     }


### PR DESCRIPTION
With these settings, a 6 second clip is about 2.5 MB (on the back camera). I basically halved the recommended settings and didn't notice much loss in quality. We can bring it down further if desired.

You should definitely test this on your device as well to see how it works with different cameras.